### PR TITLE
server: report prefix-cache reuse as usage.prompt_tokens_details.cached_tokens

### DIFF
--- a/src/mlx_dspark/generate.py
+++ b/src/mlx_dspark/generate.py
@@ -37,6 +37,7 @@ class GenResult:
     seconds: float
     finish_reason: str = "stop"  # "stop" (eos/stop-string) | "length" (hit max_new_tokens)
     lookup_rounds: int = 0       # rounds whose draft came from the free n-gram lookup
+    reused_tokens: int = 0       # prompt tokens served from the prefix cache (0 = full prefill)
     logprobs: list | None = None  # per-token [{token_id, logprob, top:[(id, logprob), …]}], if requested
 
     @property

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -519,6 +519,9 @@ class Engine:
             raise
         if self.prefix is not None and cache is not None:
             self.prefix.store(cache, ctx, prompt_ids, res.token_ids)
+        # The generate loops take `reuse_len` but don't report it back; the engine is
+        # where the number is known, so it's stamped once here for all three paths.
+        res.reused_tokens = reuse_len
         self.stats["requests"] += 1
         self.stats["prompt_tokens"] += len(prompt_ids)
         self.stats["completion_tokens"] += res.num_tokens
@@ -1918,6 +1921,9 @@ def make_handler(engine: Engine, api_key: str | None):
                 "prompt_tokens": len(prompt_ids),
                 "completion_tokens": gen_tokens,
                 "total_tokens": len(prompt_ids) + gen_tokens,
+                # n-best runs share one prefix lookup, so the reuse is the same for
+                # every row — report the first rather than summing it n times.
+                "prompt_tokens_details": {"cached_tokens": res_list[0].reused_tokens},
             }
             choices = []
             for i, res in enumerate(res_list):
@@ -2048,6 +2054,7 @@ def make_handler(engine: Engine, api_key: str | None):
                     "prompt_tokens": len(prompt_ids),
                     "completion_tokens": res.num_tokens,
                     "total_tokens": len(prompt_ids) + res.num_tokens,
+                    "prompt_tokens_details": {"cached_tokens": res.reused_tokens},
                 }
             final["x_mlx_dspark"] = engine.spec_info(res)
             self._sse(final)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,7 @@ class _FakeEngine:
         self.tokenizer = _FakeTok()
         self.calls = []
         self.response_text = "Hello world from mlx dspark"
+        self.reused_tokens = 0        # prompt tokens a prefix-cache hit would serve
 
     def generate(self, prompt_ids, *, max_tokens, temperature, top_p=1.0, top_k=0,
                  presence_penalty=0.0, frequency_penalty=0.0, logprobs=None,
@@ -63,7 +64,8 @@ class _FakeEngine:
                    "top": [(t, -0.5)] if logprobs else []} for t in [1, 2, 3, 4, 5]]
         return GenResult(text=text, token_ids=[1, 2, 3, 4, 5], num_tokens=5, num_rounds=2,
                          accept_lengths=[2, 3], target_forwards=2, seconds=0.1,
-                         finish_reason="stop", logprobs=lp)
+                         finish_reason="stop", logprobs=lp,
+                         reused_tokens=self.reused_tokens)
 
     def spec_info(self, res):
         return {"mode": self.mode, "accept_len": res.mean_accept_len,
@@ -137,6 +139,45 @@ def test_chat_stream_sse(server):
     assert content == "Hello world from mlx dspark "
     assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
     assert chunks[-1]["usage"]["completion_tokens"] == 5
+
+
+def test_usage_reports_cached_tokens(server):
+    """A prefix-cache hit is visible to the client, in the OpenAI shape.
+
+    Without it a caller can see that a request was fast but not whether it was
+    fast *because* the cache held — which is the difference between measuring
+    the cache and guessing at it.
+    """
+    eng, base = server
+    eng.reused_tokens = 0
+    c = _post(base, "/v1/chat/completions",
+              {"model": "x", "messages": [{"role": "user", "content": "hi"}]})
+    assert c["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
+
+    eng.reused_tokens = 7
+    c = _post(base, "/v1/chat/completions",
+              {"model": "x", "messages": [{"role": "user", "content": "hi"}]})
+    assert c["usage"]["prompt_tokens_details"]["cached_tokens"] == 7
+
+
+def test_stream_usage_reports_cached_tokens(server):
+    """Same field on the streamed final chunk, where clients actually read it."""
+    eng, base = server
+    eng.reused_tokens = 5
+    sse = _post(base, "/v1/chat/completions",
+                {"messages": [{"role": "user", "content": "hi"}], "stream": True,
+                 "stream_options": {"include_usage": True}}, stream=True)
+    chunks = [json.loads(l[6:]) for l in sse.split("\n\n")
+              if l.startswith("data: ") and l != "data: [DONE]"]
+    assert chunks[-1]["usage"]["prompt_tokens_details"]["cached_tokens"] == 5
+
+
+def test_completions_usage_reports_cached_tokens(server):
+    """/v1/completions shares the usage builder, so it reports it too."""
+    eng, base = server
+    eng.reused_tokens = 3
+    c = _post(base, "/v1/completions", {"model": "x", "prompt": "hi"})
+    assert c["usage"]["prompt_tokens_details"]["cached_tokens"] == 3
 
 
 def test_stop_forwarded(server):


### PR DESCRIPTION
Follow-up to #7 — thank you again for the fix there. It works well, and I've since moved my project onto mlx-dspark because of it.

## What this does

The prefix cache already computes how much of a prompt it served: `acquire()` returns it as the third element and the generate loops take it as `reuse_len`. It just never reaches the client. So a caller can see that a request was fast, but not whether it was fast *because* the cache held.

This wires that existing number into the OpenAI-shaped usage block as `prompt_tokens_details.cached_tokens`, on both paths:

- non-streaming `/v1/chat/completions` and `/v1/completions`
- the streamed final chunk, when `stream_options: {"include_usage": true}` asks for it

`GenResult` carries it back from the engine, which is the one place that knows it, so a single assignment covers all three generate paths (dspark / lookup / greedy). n-best shares one lookup, so the reuse is reported once rather than summed per row.

## Why it matters to me

I maintain a local voice assistant that talks to mlx-dspark. Cache-hit visibility is how I characterised the problem in #7 in the first place, and it is also how I caught myself misreading a *different* server's cache behaviour before I filed an incorrect report against it. Without the field I can time a request but not explain it.

With this applied, my client sees:

```
turn1  TTFT  1000ms  prompt  650  cached    0   uncached 650
turn2  TTFT   280ms  prompt  677  cached  649   uncached  28
turn3  TTFT   293ms  prompt  723  cached  676   uncached  47
```

which makes the relationship between the uncached remainder and TTFT directly measurable rather than inferred.

It also immediately surfaced something about my own setup that I could not see before. My prompt has two shapes — a tool-guidance block is appended to the system message only on turns that offer tools — so each shape has its own cold start: 2496 uncached and 5.1s on the first tool turn, then 81 uncached and 1.8s once held. Raising `--prefix-cache-slots` was the fix. I would not have found that without the field.

## Tests

Three added to `tests/test_server.py`, in the existing mock-engine style: non-streaming, streamed final chunk, and `/v1/completions`. The fake engine gained a `reused_tokens` attribute so a hit can be simulated without weights.

Full suite passes (466). `tests/test_bonsai.py::test_hybrid_full_accept_keeps_state` fails, but it fails identically on a clean checkout of `main` — unrelated to this change. `ruff check` is clean.

## Notes

- Purely additive: clients that don't look for the field are unaffected.
- Reports `0` rather than omitting the field on a miss, matching OpenAI's shape, so "was this cached?" is answerable without a special case.
- Please feel free to reject or rewrite this — you know this code and I've only just read it.
