### PR TITLE
server: native-MTP draft mode (--mode mtp) that keeps token-level prefix reuse

### DIFF
--- a/src/mlx_dspark/cli.py
+++ b/src/mlx_dspark/cli.py
@@ -57,7 +57,7 @@ def cmd_generate(argv: list[str]) -> None:
     from .lookup import lookup_generate
 
     ap = argparse.ArgumentParser(prog="mlx-dspark generate")
-    ap.add_argument("--mode", choices=["auto", "dspark", "dflash", "lookup", "baseline"],
+    ap.add_argument("--mode", choices=["auto", "dspark", "dflash", "mtp", "lookup", "baseline"],
                     default="dspark",
                     help="dspark = DSpark spec decoding; dflash = z-lab DFlash (block diffusion); "
                          "lookup = drafter-free prompt-lookup spec decoding (any target); "
@@ -246,7 +246,7 @@ def cmd_serve(argv: list[str]) -> None:
 
     ap = argparse.ArgumentParser(prog="mlx-dspark serve",
                                  description="OpenAI-compatible API server.")
-    ap.add_argument("--mode", choices=["auto", "dspark", "dflash", "lookup", "baseline"],
+    ap.add_argument("--mode", choices=["auto", "dspark", "dflash", "mtp", "lookup", "baseline"],
                     default="dspark",
                     help="'auto' picks the best available speculation for the target "
                          "(dspark -> dflash -> drafter-free lookup), so any repo serves")
@@ -267,6 +267,9 @@ def cmd_serve(argv: list[str]) -> None:
                     help="cap on tokens verified per round; <=0 = full block; 'auto' = calibrate "
                          "for this machine+model and adapt live. Default: dspark=2, lookup=6, "
                          "dflash=full block.")
+    ap.add_argument("--mtp-depth", type=int, default=3,
+                    help="mtp mode: tokens the native MTP head rolls forward per round "
+                         "(default 3). Speed-only — the target verifies every draft.")
     ap.add_argument("--default-max-tokens", type=int, default=2048,
                     help="max_tokens used when a request doesn't send one (default 2048)")
     ap.add_argument("--max-tokens-cap", type=int, default=32768,
@@ -365,6 +368,7 @@ def cmd_serve(argv: list[str]) -> None:
         "mode": args.mode, "model": args.model, "drafter": args.drafter,
         "family": args.family, "target": args.target,
         "drafter_bits": args.drafter_bits, "max_draft_tokens": max_draft,
+        "mtp_depth": args.mtp_depth,
         "confidence_threshold": args.confidence_threshold,
         "enable_thinking": False if args.no_thinking else None,
         "reasoning_effort": args.reasoning_effort,

--- a/src/mlx_dspark/generate.py
+++ b/src/mlx_dspark/generate.py
@@ -37,6 +37,7 @@ class GenResult:
     seconds: float
     finish_reason: str = "stop"  # "stop" (eos/stop-string) | "length" (hit max_new_tokens)
     lookup_rounds: int = 0       # rounds whose draft came from the free n-gram lookup
+    reused_tokens: int = 0       # prompt tokens served from the prefix cache (0 = full prefill)
     logprobs: list | None = None  # per-token [{token_id, logprob, top:[(id, logprob), …]}], if requested
 
     @property

--- a/src/mlx_dspark/generate.py
+++ b/src/mlx_dspark/generate.py
@@ -22,6 +22,7 @@ from mlx.utils import tree_flatten
 
 from .sampling import sample_probs, truncate_probs
 from .wide_gemm import wide_matmul
+from .target import POST_NORM
 
 TAP = None  # set from drafter config at call time
 
@@ -735,7 +736,8 @@ def _prefill_tapped(target, ids: list[int], cache, tap, drafter=None, ctx_caches
                                            want_logits=last,
                                            head_last_row=PREFILL_LAST_ROW_HEAD)
             if drafter is not None:
-                drafter.update_context(fused, ctx_offset=pos, ctx_caches=ctx_caches)
+                drafter.update_context(fused, ctx_offset=pos, ctx_caches=ctx_caches,
+                                       token_ids=piece)
             else:
                 parts.append(fused)
             pos += len(piece)
@@ -862,12 +864,21 @@ def speculative_generate(
     cfg = drafter.config
     # DFlash-warm-started heads reuse the target's own embed_tokens and/or lm_head (they ship
     # neither weight): Nemotron reuses the head, Muse-Glimmer reuses both. Bind what's reused.
-    if not getattr(cfg, "has_own_lm_head", True):
+    # A native-MTP head ships neither by construction, and taps the post-norm final hidden
+    # rather than a set of residual-stream layers — the tensor the target already computes
+    # for its own lm_head, so the tap costs nothing extra.
+    if getattr(drafter, "sequential", False):
         drafter.bind_lm_head(target_model.lm_head_proj)
-    if not getattr(cfg, "has_own_embed", True):
         drafter.bind_embed(target_model.draft_embed)
-    tap = list(cfg.target_layer_ids)
-    mask_id = cfg.mask_token_id
+        tap = POST_NORM
+        mask_id = None
+    else:
+        if not getattr(cfg, "has_own_lm_head", True):
+            drafter.bind_lm_head(target_model.lm_head_proj)
+        if not getattr(cfg, "has_own_embed", True):
+            drafter.bind_embed(target_model.draft_embed)
+        tap = list(cfg.target_layer_ids)
+        mask_id = cfg.mask_token_id
     # A DFlash-derived head spends slot 0 on the anchor, so it can propose block_size-1.
     kdraft = drafter.max_draft
     cap_ceiling = kdraft if max_draft_tokens is None else max(1, min(max_draft_tokens, kdraft))
@@ -953,7 +964,8 @@ def speculative_generate(
             y = mx.array([[pending]])
             logits, fused = target_model.verify(y, cache, tap)
             nxt_arr = mx.argmax(logits[0, -1])
-            drafter.update_context(fused, ctx_offset=n_cached, ctx_caches=ctx_caches)
+            drafter.update_context(fused, ctx_offset=n_cached, ctx_caches=ctx_caches,
+                                   token_ids=[pending])
             n_cached += 1
             mx.async_eval(nxt_arr, [c.k for c in ctx_caches])
             while True:
@@ -980,7 +992,8 @@ def speculative_generate(
                 y = nxt_arr.reshape(1, 1)
                 logits, fused = target_model.verify(y, cache, tap)
                 nxt_next = mx.argmax(logits[0, -1])
-                drafter.update_context(fused, ctx_offset=n_cached, ctx_caches=ctx_caches)
+                drafter.update_context(fused, ctx_offset=n_cached, ctx_caches=ctx_caches,
+                                       token_ids=[pending])
                 n_cached += 1
                 mx.async_eval(nxt_next, [c.k for c in ctx_caches])
                 nxt_arr = nxt_next
@@ -1022,6 +1035,52 @@ def speculative_generate(
                 n_arr = mx.cumprod(match).sum()
                 mx.eval(n_arr, tt_arr)
                 n = int(n_arr.item())
+                tt = tt_arr.tolist()
+                committed = draft[:n] + [tt[n]]
+        elif getattr(drafter, "sequential", False):
+            # ---- 1'. draft sequentially (native MTP head) ----
+            # An MTP head cannot produce depth d+1 before depth d is sampled, so the block
+            # path below does not apply: the head rolls itself forward, feeding each depth
+            # the previous depth's token and its own post-norm hidden. The rollout stays on
+            # device (drafted tokens are embedded as arrays, never `.item()`d), so the
+            # greedy default keeps the property the fused block path has — draft heads,
+            # verify forward and accept still reach the GPU as one graph with one sync.
+            #
+            # Verification and acceptance are the shared ones below/above, untouched. That
+            # is what makes this lossless for the same reason the block path is: the target
+            # checks every drafted token, so a sequential proposal changes only how many
+            # survive, never what is emitted.
+            draft_arr, q_probs = drafter.draft_block(
+                pending, n_cached, ctx_caches, cap,
+                temperature=temperature, top_p=top_p, top_k=top_k)
+            if temperature > 0.0 or pen.active or lp_list is not None:
+                mx.eval(draft_arr, q_probs)
+                draft = [int(x) for x in draft_arr.tolist()]
+                verify_ids = mx.array([[pending] + draft])
+                v_logits, v_fused = target_model.verify(verify_ids, cache, tap)
+                mx.eval(v_logits, v_fused)
+                if temperature > 0.0:
+                    n, repl = _spec_sample_accept(
+                        pen.apply(v_logits[0], draft), draft, q_probs,
+                        temperature, top_p, top_k)
+                    committed = draft[:n] + [repl]
+                else:
+                    tt = [int(x) for x in mx.argmax(
+                        pen.apply(v_logits[0], draft), axis=-1).tolist()]
+                    n = 0
+                    while n < len(draft) and draft[n] == tt[n]:
+                        n += 1
+                    committed = draft[:n] + [tt[n]]
+            else:
+                verify_ids = mx.concatenate(
+                    [mx.array([pending], dtype=draft_arr.dtype), draft_arr]).reshape(1, -1)
+                v_logits, v_fused = target_model.verify(verify_ids, cache, tap)
+                tt_arr = mx.argmax(v_logits[0], axis=-1)
+                match = (draft_arr == tt_arr[: draft_arr.shape[0]]).astype(mx.int32)
+                n_arr = mx.cumprod(match).sum()
+                mx.eval(n_arr, tt_arr, draft_arr)
+                n = int(n_arr.item())
+                draft = draft_arr.tolist()
                 tt = tt_arr.tolist()
                 committed = draft[:n] + [tt[n]]
         else:
@@ -1134,8 +1193,11 @@ def speculative_generate(
         # ---- 4. update caches/context ----
         target_model.rollback(cache, len(draft) - n, draft[:n])
         # commit [pending, accepted drafts] (positions n_cached..n_cached+n) as context
+        # token_ids are the *input* tokens at these positions — the anchor plus the
+        # accepted drafts — which is what a native-MTP head fuses against each hidden.
         drafter.update_context(
-            v_fused[:, : n + 1, :], ctx_offset=n_cached, ctx_caches=ctx_caches
+            v_fused[:, : n + 1, :], ctx_offset=n_cached, ctx_caches=ctx_caches,
+            token_ids=[pending] + draft[:n],
         )
         n_cached = n_cached + n + 1
         # schedule (don't block): the ctx projections run while Python commits tokens and

--- a/src/mlx_dspark/generate.py
+++ b/src/mlx_dspark/generate.py
@@ -21,8 +21,8 @@ import mlx.core as mx
 from mlx.utils import tree_flatten
 
 from .sampling import sample_probs, truncate_probs
-from .wide_gemm import wide_matmul
 from .target import POST_NORM
+from .wide_gemm import wide_matmul
 
 TAP = None  # set from drafter config at call time
 

--- a/src/mlx_dspark/load.py
+++ b/src/mlx_dspark/load.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import glob
+import json
 import os
 
 import mlx.core as mx
@@ -705,3 +706,62 @@ def load_dflash_pair(model: str = "gemma4", *, drafter: str | None = None):
     drafter_m, cfg = load_dflash(drafter_repo)
     drafter_m.bind(target.model)
     return target, tok, drafter_m, cfg
+
+
+def load_mtp(repo_or_path: str, *, text_config: dict | None = None, max_depth: int = 3,
+             quantize: bool = False, bits: int = 8, group_size: int = 64):
+    """Return (MTP drafter, MTPConfig) for a checkpoint that ships Qwen's ``mtp.`` tensors.
+
+    ``repo_or_path`` may be a full model directory/repo (the MTP block travels inside the
+    base Qwen checkpoint) or a directory holding just ``mtp.safetensors``; both are read
+    the same way, since the 15 tensor names are identical either way.
+
+    ``text_config`` is the *target's* config, because the head is a sibling of the trunk's
+    full-attention layers and shares their geometry. Passing the target's own config is
+    what keeps head_dim / partial rope / rope_theta from drifting apart from the model the
+    head was trained against. When omitted it is read from ``config.json`` next to the
+    weights.
+
+    Left in bf16 by default (~0.85 GB for Qwen3.8-27B). Unlike the 6.9 GB DSpark drafter,
+    the MTP block is small enough that quantizing it buys little, and the published
+    MTP-bearing checkpoints keep it at full precision — so this matches what the head was
+    measured at rather than saving half a gigabyte.
+    """
+    from .mtp_model import MTPConfig, MTPDrafter
+
+    path = _resolve(repo_or_path)
+    if text_config is None:
+        with open(os.path.join(path, "config.json")) as f:
+            cfg_json = json.load(f)
+        text_config = cfg_json.get("text_config", cfg_json)
+
+    weights: dict[str, mx.array] = {}
+    for st in glob.glob(os.path.join(path, "*.safetensors")):
+        weights.update({k[len("mtp."):]: v for k, v in mx.load(st).items()
+                        if k.startswith("mtp.")})
+    if not weights:
+        raise ValueError(
+            f"{repo_or_path}: no `mtp.*` tensors found. Native-MTP drafting needs a "
+            f"checkpoint that ships Qwen's MTP block — the base Qwen/Qwen3.8-27B repo does, "
+            f"as do the `*-MTP-*` MLX conversions; most MLX conversions drop it.")
+
+    config = MTPConfig.from_text_config(text_config, max_depth=max_depth)
+    drafter = MTPDrafter(config)
+
+    # Same standard as load_drafter: a partially-loaded head runs and drafts badly, which
+    # costs throughput with no error to trace it to. Refuse instead.
+    model_keys = {k for k, _ in _flatten_params(drafter)}
+    missing = sorted(model_keys - set(weights))
+    unexpected = sorted(set(weights) - model_keys)
+    if missing or unexpected:
+        raise ValueError(
+            f"{repo_or_path}: MTP tensor names don't match Qwen's MTP block."
+            f"\n  missing in checkpoint ({len(missing)}): {missing[:8]}"
+            f"\n  unexpected in checkpoint ({len(unexpected)}): {unexpected[:8]}")
+
+    drafter.load_weights(list(weights.items()))
+    if quantize:
+        nn.quantize(drafter, group_size=group_size, bits=bits,
+                    class_predicate=lambda p, m: isinstance(m, nn.Linear))
+    mx.eval(drafter.parameters())
+    return drafter, config

--- a/src/mlx_dspark/model.py
+++ b/src/mlx_dspark/model.py
@@ -373,7 +373,11 @@ class DSparkDrafter(nn.Module):
     def make_ctx_cache(self) -> list[CtxCache]:
         return [CtxCache() for _ in self.layers]
 
-    def update_context(self, target_hidden_cat, ctx_offset, ctx_caches) -> None:
+    def update_context(self, target_hidden_cat, ctx_offset, ctx_caches,
+                       token_ids=None) -> None:
+        """``token_ids`` is accepted and ignored: this head's context is a function of the
+        target's hidden states alone. A native-MTP head additionally fuses the *next* token
+        at each position, so the shared prefill/spec loop passes them to every drafter."""
         fused = self.fuse_target(target_hidden_cat)
         for layer, cache in zip(self.layers, ctx_caches):
             layer.self_attn.update_ctx(fused, ctx_offset, cache)

--- a/src/mlx_dspark/mtp_model.py
+++ b/src/mlx_dspark/mtp_model.py
@@ -82,7 +82,7 @@ class MTPConfig:
         self.max_depth = max_depth
 
     @classmethod
-    def from_text_config(cls, tc: dict, *, max_depth: int = 3) -> "MTPConfig":
+    def from_text_config(cls, tc: dict, *, max_depth: int = 3) -> MTPConfig:
         """Read the MTP block's shape off the target's own text config.
 
         The head is a sibling of the trunk's full-attention layers and shares their

--- a/src/mlx_dspark/mtp_model.py
+++ b/src/mlx_dspark/mtp_model.py
@@ -1,0 +1,359 @@
+"""Native MTP drafter — Qwen3.5/Qwen3-Next multi-token-prediction heads as a draft source.
+
+Qwen ships an MTP head inside the base checkpoint (15 tensors under ``mtp.``): one
+standard attention layer, an ``fc`` that fuses ``concat(embedding, hidden)``, and the
+norms around them. It carries no ``embed_tokens`` and no ``lm_head`` — it reuses the
+target's, exactly like the DFlash-warm-started DSpark heads already do here
+(``has_own_embed`` / ``has_own_lm_head`` + ``bind_embed`` / ``bind_lm_head``).
+
+The head is trained jointly with the trunk, which is why it accepts more per round than
+a separately distilled drafter: measured 2.18 tokens committed per verify against the
+DSpark head's 1.38 on the same Japanese chat prompt (M5 Max, Qwen3.8-27B-8bit).
+
+**Why this is a drafter and not a second engine.** The one thing that matters for a
+long conversation is that the draft state can be rolled back to an arbitrary earlier
+position, because that is what lets the prefix cache reuse a prompt down to the token
+instead of to a block boundary. The MTP layer is *full* attention — it is not one of
+the 48 ``linear_attention`` layers of the Qwen3.8 trunk — so its K/V rows are
+position-local and trim exactly, which is the same property ``prefix_cache`` already
+relies on for the DSpark drafter context. So this reuses :class:`CtxCache` verbatim
+rather than introducing a second cache shape.
+
+**The contract.** Getting any of this wrong does not raise — it silently drafts worse,
+which reads as "MTP is not actually better". Both of the following agree, and the
+per-depth acceptance measured after implementing (see ``tests/test_mtp.py``) is the
+check that they were read correctly:
+
+    e = pre_fc_norm_embedding(embed(next_token))
+    h = pre_fc_norm_hidden(hidden)
+    x = fc(concat([e, h]))            # concat_order = "embedding_hidden"
+    x = layer(x)                      # one standard attention block
+    logits = lm_head(norm(x))         # target's head
+    hidden_for_next_depth = norm(x)   # hidden_variant = "post_norm"
+
+with the depth-1 ``hidden`` being the trunk's *post-norm* final hidden
+(``base_hidden_variant = "post_norm"``) — the same tensor the trunk feeds its own
+lm_head, which :meth:`Target.run` already computes and currently discards.
+
+**Indexing.** MTP position ``t`` fuses ``(hidden_t, embed(x_{t+1}))`` and predicts
+``x_{t+2}``. So a context of ``N`` committed tokens supports exactly ``N-1`` MTP rows:
+the last hidden has no next token yet. That "always one behind" is the invariant this
+module keeps (:meth:`ctx_len_for`), and it is what makes the context a pure function of
+the committed prefix — which is what the prefix cache needs in order to snapshot it.
+The unpaired last hidden is per-request scratch (:attr:`_tail`), never snapshotted; a
+restored request always re-forwards at least one token (the prefix cache deliberately
+snapshots below the prompt boundary), so it is always refilled before it is read.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .model import CtxCache
+
+
+class MTPConfig:
+    """Shape of the ``mtp.`` block, read off the checkpoint's text config."""
+
+    def __init__(self, hidden_size: int, num_attention_heads: int, num_key_value_heads: int,
+                 head_dim: int, intermediate_size: int, rms_norm_eps: float = 1e-6,
+                 rope_theta: float = 100000.0, rope_parameters=None,
+                 partial_rotary_factor: float = 0.25, max_position_embeddings: int = 131072,
+                 attention_bias: bool = False, max_depth: int = 3):
+        self.hidden_size = hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.intermediate_size = intermediate_size
+        self.rms_norm_eps = rms_norm_eps
+        self.rope_theta = rope_theta
+        self.rope_parameters = rope_parameters
+        # Qwen3-Next ropes only the first `head_dim * partial_rotary_factor` dims (64 of
+        # 256 on Qwen3.8). Roping all of them loads fine and drafts nonsense-adjacent
+        # tokens that the target rejects — a throughput bug with no error attached.
+        self.partial_rotary_factor = partial_rotary_factor
+        self.max_position_embeddings = max_position_embeddings
+        self.attention_bias = attention_bias
+        # Depth is a speed/quality dial, not a correctness one: the target verifies every
+        # drafted token, so a bad depth costs throughput and never output. Measured
+        # per-depth acceptance on Japanese chat is [0.70, 0.29, 0.18] — depth 3 is the
+        # point where the marginal draft token stops paying for its verify row.
+        self.max_depth = max_depth
+
+    @classmethod
+    def from_text_config(cls, tc: dict, *, max_depth: int = 3) -> "MTPConfig":
+        """Read the MTP block's shape off the target's own text config.
+
+        The head is a sibling of the trunk's full-attention layers and shares their
+        geometry, so every value here comes from the same place mlx-lm's
+        ``Qwen3_5.TextModelArgs`` reads it — including the defaults, because Qwen3.8's
+        config leaves ``rope_theta`` unset and nests the rope settings under
+        ``rope_parameters``.
+        """
+        h = tc["hidden_size"]
+        n_heads = tc.get("num_attention_heads", 16)
+        n_kv = tc.get("num_key_value_heads", n_heads)
+        head_dim = tc.get("head_dim") or (h // n_heads)
+        rp = tc.get("rope_parameters") or {}
+        return cls(
+            hidden_size=h,
+            num_attention_heads=n_heads,
+            num_key_value_heads=n_kv,
+            head_dim=head_dim,
+            intermediate_size=tc.get("intermediate_size", 4 * h),
+            rms_norm_eps=tc.get("rms_norm_eps", 1e-6),
+            rope_theta=rp.get("rope_theta", tc.get("rope_theta") or 100000.0),
+            rope_parameters=tc.get("rope_scaling"),
+            partial_rotary_factor=rp.get(
+                "partial_rotary_factor", tc.get("partial_rotary_factor", 0.25)),
+            max_position_embeddings=tc.get("max_position_embeddings", 131072),
+            attention_bias=bool(tc.get("attention_bias", False)),
+            max_depth=max_depth,
+        )
+
+
+class MTPAttention(nn.Module):
+    """The MTP layer's attention — Qwen3-Next's ``Attention``, driven by a :class:`CtxCache`.
+
+    Kept a faithful mirror of ``mlx_lm.models.qwen3_next.Qwen3NextAttention`` rather than
+    a generic GQA block, because two of its quirks are load-bearing and neither of them
+    fails loudly if you get it wrong:
+
+      * **gated ``q_proj``** — it emits ``2 · n_heads · head_dim`` and the second half is
+        a per-head gate applied as ``o_proj(out · sigmoid(gate))``. Reading it as a plain
+        projection makes the shapes work only if you also halve the head count, and the
+        head then drafts from the wrong subspace.
+      * **partial rope** — only ``head_dim · partial_rotary_factor`` dims are rotated
+        (64 of 256 on Qwen3.8).
+
+    Both would load cleanly and simply accept less, which is indistinguishable from
+    "native MTP is not worth it" unless the acceptance rate is measured against a
+    reference. That is why :func:`load_mtp` checks tensor names strictly and the bench
+    reports per-depth acceptance.
+    """
+
+    def __init__(self, config: MTPConfig):
+        super().__init__()
+        try:  # mlx-lm keeps the rope factory next to the model families
+            from mlx_lm.models.rope_utils import initialize_rope
+        except ImportError:  # older layouts
+            from mlx_lm.models.base import initialize_rope
+
+        self.n_heads = config.num_attention_heads
+        self.n_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim ** -0.5
+        h, b = config.hidden_size, config.attention_bias
+        self.q_proj = nn.Linear(h, self.n_heads * self.head_dim * 2, bias=b)
+        self.k_proj = nn.Linear(h, self.n_kv_heads * self.head_dim, bias=b)
+        self.v_proj = nn.Linear(h, self.n_kv_heads * self.head_dim, bias=b)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, h, bias=b)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.rope = initialize_rope(
+            int(self.head_dim * config.partial_rotary_factor),
+            base=config.rope_theta,
+            traditional=False,
+            scaling_config=config.rope_parameters,
+            max_position_embeddings=config.max_position_embeddings,
+        )
+
+    def _q_and_gate(self, x: mx.array, offset: int):
+        B, S, _ = x.shape
+        q, gate = mx.split(self.q_proj(x).reshape(B, S, self.n_heads, -1), 2, axis=-1)
+        q = self.rope(self.q_norm(q).transpose(0, 2, 1, 3), offset=offset)
+        return q, gate.reshape(B, S, -1)
+
+    def kv(self, x: mx.array, offset: int):
+        """Project ``x`` [1, S, H] -> (roped+normed K, V) at absolute positions ``offset``…
+
+        Split out from :meth:`attend` because committing context rows needs the K/V and
+        nothing else: the layer output at a committed position is never read again, so
+        building the context costs projections only — no attention, no MLP.
+        """
+        B, S, _ = x.shape
+        k = self.k_proj(x).reshape(B, S, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = self.rope(self.k_norm(k), offset=offset)
+        v = self.v_proj(x).reshape(B, S, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        return k, v
+
+    def attend(self, x: mx.array, offset: int, cache: CtxCache) -> mx.array:
+        """Append ``x``'s K/V to ``cache`` and attend over everything held.
+
+        Appending before attending is what lets a row see itself, which the depth-1 query
+        needs: its own (hidden, next-token) pair is the newest row of its own context.
+        """
+        B, S, _ = x.shape
+        q, gate = self._q_and_gate(x, offset)
+        k, v = self.kv(x, offset)
+        cache.append(k, v)
+        out = mx.fast.scaled_dot_product_attention(
+            q, cache.k, cache.v, scale=self.scale, mask="causal" if S > 1 else None)
+        out = out.transpose(0, 2, 1, 3).reshape(B, S, -1)
+        return self.o_proj(out * mx.sigmoid(gate))
+
+
+class MTPLayer(nn.Module):
+    def __init__(self, config: MTPConfig):
+        super().__init__()
+        self.self_attn = MTPAttention(config)
+        h, i = config.hidden_size, config.intermediate_size
+        self.mlp = _MLP(h, i)
+        self.input_layernorm = nn.RMSNorm(h, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(h, eps=config.rms_norm_eps)
+
+    def __call__(self, x: mx.array, offset: int, cache: CtxCache) -> mx.array:
+        x = x + self.self_attn.attend(self.input_layernorm(x), offset, cache)
+        return x + self.mlp(self.post_attention_layernorm(x))
+
+
+class _MLP(nn.Module):
+    def __init__(self, h: int, i: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(h, i, bias=False)
+        self.up_proj = nn.Linear(h, i, bias=False)
+        self.down_proj = nn.Linear(i, h, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class MTPDrafter(nn.Module):
+    """The ``mtp.`` block as a draft source for :func:`speculative_generate`.
+
+    Exposes the pieces of the drafter protocol the shared spec loop actually calls for a
+    sequential head: :meth:`make_ctx_cache`, :meth:`update_context` and
+    :meth:`draft_block`. It does *not* implement the block-parallel protocol
+    (``backbone`` / ``sample_block``) — an MTP head cannot produce position ``d+1``
+    before position ``d`` is sampled, so the block path does not apply and the loop
+    branches on :attr:`sequential`.
+    """
+
+    sequential = True
+    #: no confidence head — the depth loop stops at ``max_depth``
+    confidence_head = None
+
+    def __init__(self, config: MTPConfig):
+        super().__init__()
+        self.config = config
+        h = config.hidden_size
+        self.fc = nn.Linear(2 * h, h, bias=False)
+        self.pre_fc_norm_embedding = nn.RMSNorm(h, eps=config.rms_norm_eps)
+        self.pre_fc_norm_hidden = nn.RMSNorm(h, eps=config.rms_norm_eps)
+        self.layers = [MTPLayer(config)]
+        self.norm = nn.RMSNorm(h, eps=config.rms_norm_eps)
+        self._embed = None      # bound to the target's embed_tokens
+        self._lm_head = None    # bound to the target's lm_head projection
+        # The hidden whose next token is not known yet — see the module docstring.
+        self._tail: mx.array | None = None
+
+    # -- binding to the target (MTP ships neither weight) ---------------------------
+
+    def bind_embed(self, embed_fn) -> None:
+        self._embed = embed_fn
+
+    def bind_lm_head(self, project) -> None:
+        self._lm_head = project
+
+    @property
+    def max_draft(self) -> int:
+        return self.config.max_depth
+
+    # -- context -------------------------------------------------------------------
+
+    def make_ctx_cache(self) -> list[CtxCache]:
+        self._tail = None
+        return [CtxCache() for _ in self.layers]
+
+    @staticmethod
+    def ctx_len_for(n_tokens: int) -> int:
+        """Rows a context of ``n_tokens`` committed tokens supports. See the docstring."""
+        return max(0, n_tokens - 1)
+
+    def _fuse(self, hidden: mx.array, token_ids: mx.array) -> mx.array:
+        """``fc(concat(norm_e(embed(next_token)), norm_h(hidden)))`` — the contract."""
+        e = self.pre_fc_norm_embedding(self._embed(token_ids))
+        h = self.pre_fc_norm_hidden(hidden)
+        return self.fc(mx.concatenate([e, h], axis=-1))
+
+    def update_context(self, hidden: mx.array, ctx_offset: int, ctx_caches,
+                       token_ids=None) -> None:
+        """Commit context rows.
+
+        ``hidden`` [1, m, H] are the trunk's post-norm hiddens at absolute positions
+        ``ctx_offset … ctx_offset+m-1``; ``token_ids`` are the *input* tokens at those
+        same positions — which is what every caller already has (the prompt ids during
+        prefill, ``[pending] + committed`` during the round).
+
+        Row ``i`` needs the token at position ``ctx_offset+i+1``, so this pairs each
+        hidden with the *following* entry of ``token_ids`` and carries the last hidden
+        over in :attr:`_tail`, together with the previous call's tail paired against
+        ``token_ids[0]``. Net effect: after the call the context holds exactly
+        ``ctx_offset+m-1`` rows, matching :meth:`ctx_len_for`.
+        """
+        if token_ids is None:
+            raise ValueError("MTP context needs the tokens at these positions")
+        toks = token_ids if isinstance(token_ids, mx.array) else mx.array(token_ids)
+        toks = toks.reshape(1, -1)
+        m = hidden.shape[1]
+
+        carried, rows, ids = self._tail, [], []
+        if carried is not None:
+            # last call's unpaired hidden (position ctx_offset-1), now that its next
+            # token — the first token of this call — has arrived
+            rows.append(carried)
+            ids.append(toks[:, :1])
+        if m > 1:
+            rows.append(hidden[:, : m - 1, :])
+            ids.append(toks[:, 1:m])
+        self._tail = hidden[:, m - 1 :, :]
+        if not rows:
+            return
+
+        # Committed rows are contiguous: ctx_offset-1 … when a tail was carried in,
+        # ctx_offset … when this is the first call on a fresh context.
+        start = ctx_offset - 1 if carried is not None else ctx_offset
+        fused = self._fuse(mx.concatenate(rows, axis=1), mx.concatenate(ids, axis=1))
+        x = self.layers[0].input_layernorm(fused)
+        k, v = self.layers[0].self_attn.kv(x, start)
+        ctx_caches[0].append(k, v)
+
+    # -- drafting ------------------------------------------------------------------
+
+    def draft_block(self, pending: int, n_cached: int, ctx_caches, cap: int,
+                    temperature: float = 0.0, top_p: float = 1.0, top_k: int = 0):
+        """Draft up to ``cap`` tokens, sequentially by depth.
+
+        Returns ``(draft_arr, q_probs)`` with ``draft_arr`` an ``[d]`` device array and
+        ``q_probs`` the ``[d, V]`` proposal distributions (``None`` when greedy). Nothing
+        is synced to the host: each depth embeds the previous depth's sampled token as a
+        device array, so the whole rollout — and the verify forward after it — still
+        reaches the device as one graph.
+
+        The rows appended here are speculative, so the context is trimmed back to its
+        committed length before returning; the accepted ones are re-committed from the
+        target's own hiddens by :meth:`update_context`.
+        """
+        cache = ctx_caches[0]
+        committed_len = cache.length
+        depth = max(1, min(cap, self.config.max_depth))
+
+        hidden = self._tail                       # trunk hidden at position n_cached-1
+        tok = mx.array([[pending]])
+        drafts, qs = [], []
+        for d in range(depth):
+            fused = self._fuse(hidden, tok)
+            x = self.layers[0](fused, committed_len + d, cache)
+            hidden = self.norm(x)                 # hidden_variant = "post_norm"
+            logits = self._lm_head(hidden)[:, -1, :]
+            if temperature > 0.0:
+                probs = mx.softmax(logits.astype(mx.float32) / temperature, axis=-1)
+                qs.append(probs[0])
+                tok = mx.random.categorical(mx.log(probs)).reshape(1, 1)
+            else:
+                tok = mx.argmax(logits, axis=-1).reshape(1, 1)
+            drafts.append(tok.reshape(1))
+        cache.trim_to(committed_len)              # speculative rows are not context
+        draft_arr = mx.concatenate(drafts)
+        return draft_arr, (mx.stack(qs) if qs else None)

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -43,13 +43,14 @@ from .generate import (
     greedy_generate,
     speculative_generate,
 )
-from .load import apply_wired_limit, load_dflash, load_drafter, load_target, resolve_mode
+from .load import (apply_wired_limit, load_dflash, load_drafter, load_mtp, load_target,
+                   resolve_mode)
 from .lookup import lookup_generate
 from .prefix_cache import PrefixCache, _lcp, target_cache_reusable
 from .telemetry import RoundLog, RoundRecorder
 from .tools import normalize_tool_messages, parse_tool_calls, schema_types
 
-MODES = ("dspark", "dflash", "lookup", "baseline")
+MODES = ("dspark", "dflash", "mtp", "lookup", "baseline")
 
 # The union of effort vocabularies across template lineages (Qwen3.8 knows low/medium/xhigh,
 # harmony-style templates low/medium/high). Values outside a given template's own vocabulary
@@ -203,14 +204,20 @@ class Engine:
         at all (hybrid linear-attention: Ornith, Bonsai, Qwen3.6-27B). Those used to get no
         prefix caching whatsoever, which cost them the agent workload outright: prefill is
         ~90% of an uncached Claude Code turn. Still disabled for DFlash (its *drafter*
-        cache can't roll back, and it isn't snapshotted here)."""
+        cache can't roll back, and it isn't snapshotted here).
+
+        **Enabled for mtp**, deliberately: a native MTP head is one full-attention layer,
+        so its context is position-local K/V that trims exactly — the same property the
+        DSpark drafter context has. That is what lets the head ride the existing snapshot
+        machinery instead of forcing restores onto block boundaries."""
         if not enabled or self.mode == "dflash":
             return None
         try:
             checkpoint = not target_cache_reusable(self.target.make_cache())
         except Exception:  # noqa: BLE001
             return None
-        make_ctx = self.drafter.make_ctx_cache if self.mode == "dspark" else None
+        make_ctx = (self.drafter.make_ctx_cache
+                    if self.mode in ("dspark", "mtp") else None)
         return PrefixCache(self.target.make_cache, make_ctx,
                            l2_dir=l2_dir, max_ram_bytes=max(0, max_ram_mb) * 1024 * 1024,
                            slots=self.prefix_cache_slots, checkpoint=checkpoint)
@@ -297,6 +304,10 @@ class Engine:
         family: str | None = None,     # deprecated alias for `model`
         target: str | None = None,     # deprecated alias for `model`
         drafter_bits: int = 4,
+        # mtp mode: how many tokens the head rolls itself forward per round. Measured
+        # per-depth acceptance on Japanese chat is [0.70, 0.29, 0.18], so 3 is where the
+        # marginal draft token stops paying for its verify row. Speed-only, like the cap.
+        mtp_depth: int = 3,
         max_draft_tokens: int | str | None = None,   # int, None (mode default) or "auto"
         confidence_threshold: float = 0.0,
         enable_thinking: bool | None = None,
@@ -341,7 +352,7 @@ class Engine:
         executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-gen")
 
         def _load_models():
-            tgt, tok = load_target(target_repo, require_tap=mode in ("dspark", "dflash"),
+            tgt, tok = load_target(target_repo, require_tap=mode in ("dspark", "dflash", "mtp"),
                                    kv_bits=kv_bits)
             draft = None
             if mode == "dspark":
@@ -351,10 +362,14 @@ class Engine:
                 draft, _ = load_dflash(drafter_repo, quantize=drafter_bits > 0,
                                        bits=max(drafter_bits, 2))
                 draft.bind(tgt.model)
+            elif mode == "mtp":
+                # Qwen ships the MTP block inside the base checkpoint; `--drafter` points
+                # at a separate one for the MLX conversions that dropped it.
+                draft, _ = load_mtp(drafter_repo or target_repo, max_depth=mtp_depth)
             # --max-draft auto: measure this machine+pair's cost curves once (disk-cached)
             # and let a CapController pick the cap per round. Only meaningful with a drafter.
             ctrl = None
-            if max_draft_tokens == "auto" and mode in ("dspark", "dflash"):
+            if max_draft_tokens == "auto" and mode in ("dspark", "dflash"):  # not mtp: depth, not width
                 from .calibrate import calibrate
 
                 ctrl = calibrate(tgt, draft, mode=mode, target_repo=target_repo,
@@ -472,7 +487,10 @@ class Engine:
                     elif pos < _stable:
                         self.prefix.rung(c, pos)
         try:
-            if self.mode == "dspark":
+            if self.mode in ("dspark", "mtp"):
+                # Same loop: the MTP head only changes how the draft is produced,
+                # so lookup, penalties, logprobs, stops, the cap controller and the
+                # prefix-cache hooks are shared rather than reimplemented.
                 res = speculative_generate(
                     self.target, self.tokenizer, self.drafter, prompt_ids=prompt_ids,
                     cache=cache, ctx_caches=ctx, reuse_len=reuse_len,

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -43,8 +43,7 @@ from .generate import (
     greedy_generate,
     speculative_generate,
 )
-from .load import (apply_wired_limit, load_dflash, load_drafter, load_mtp, load_target,
-                   resolve_mode)
+from .load import apply_wired_limit, load_dflash, load_drafter, load_mtp, load_target, resolve_mode
 from .lookup import lookup_generate
 from .prefix_cache import PrefixCache, _lcp, target_cache_reusable
 from .telemetry import RoundLog, RoundRecorder

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -519,6 +519,9 @@ class Engine:
             raise
         if self.prefix is not None and cache is not None:
             self.prefix.store(cache, ctx, prompt_ids, res.token_ids)
+        # The generate loops take `reuse_len` but don't report it back; the engine is
+        # where the number is known, so it's stamped once here for all three paths.
+        res.reused_tokens = reuse_len
         self.stats["requests"] += 1
         self.stats["prompt_tokens"] += len(prompt_ids)
         self.stats["completion_tokens"] += res.num_tokens
@@ -1918,6 +1921,9 @@ def make_handler(engine: Engine, api_key: str | None):
                 "prompt_tokens": len(prompt_ids),
                 "completion_tokens": gen_tokens,
                 "total_tokens": len(prompt_ids) + gen_tokens,
+                # n-best runs share one prefix lookup, so the reuse is the same for
+                # every row — report the first rather than summing it n times.
+                "prompt_tokens_details": {"cached_tokens": res_list[0].reused_tokens},
             }
             choices = []
             for i, res in enumerate(res_list):
@@ -2048,6 +2054,7 @@ def make_handler(engine: Engine, api_key: str | None):
                     "prompt_tokens": len(prompt_ids),
                     "completion_tokens": res.num_tokens,
                     "total_tokens": len(prompt_ids) + res.num_tokens,
+                    "prompt_tokens_details": {"cached_tokens": res.reused_tokens},
                 }
             final["x_mlx_dspark"] = engine.spec_info(res)
             self._sse(final)

--- a/src/mlx_dspark/target.py
+++ b/src/mlx_dspark/target.py
@@ -20,6 +20,25 @@ from contextlib import contextmanager
 
 import mlx.core as mx
 
+#: ``tap`` sentinel: capture the **post-norm final hidden** instead of a set of
+#: intermediate residual-stream layers. This is the tensor the target already feeds its
+#: own lm_head, and it is what a native MTP head consumes (``base_hidden_variant =
+#: "post_norm"``). Every body below computes it anyway, so passing this only stops it
+#: being discarded — the MTP draft path costs the target no extra work.
+POST_NORM = "post_norm"
+
+
+def _tapset(tap):
+    """Layer indices to capture. The POST_NORM sentinel captures none of them."""
+    return set(tap) if isinstance(tap, (list, tuple, set)) else ()
+
+
+def _captured(tap, captured, hn):
+    """What ``run``/``verify`` hand back as ``fused``, per tap kind."""
+    if tap is POST_NORM:
+        return hn
+    return mx.concatenate(captured, axis=-1) if tap is not None else None
+
 
 class Target:
     def __init__(self, model, tokenizer, *, kv_bits: int | None = None,
@@ -100,6 +119,14 @@ class Target:
         if self._muse:
             return self._run_muse_glimmer(ids, cache, tap)
         if self.is_vlm:
+            if tap is POST_NORM:
+                # The mlx-vlm capture hook returns tapped residual-stream layers, not the
+                # post-norm hidden, and there is no hook for the latter. Refuse rather than
+                # hand an MTP head the wrong tensor — it would draft plausibly and accept
+                # badly, which reads as "MTP is not worth it" instead of as a bug.
+                raise ValueError(
+                    "POST_NORM capture is not available on mlx-vlm targets; native-MTP "
+                    "drafting currently supports the mlx-lm dense and hybrid paths.")
             out = self.model.language_model(inputs=ids, cache=cache, capture_layer_ids=tap)
             return out.logits, mx.concatenate(out.hidden_states, axis=-1)
         if self._recurrence == "mamba2":
@@ -116,7 +143,7 @@ class Target:
         from mlx_lm.models.base import create_attention_mask
 
         mm = self._inner.model
-        tapset = set(tap) if tap is not None else ()
+        tapset = _tapset(tap)
         h = mm.embed_tokens(ids)
         mask = create_attention_mask(h, cache[0])
         captured = []
@@ -124,7 +151,8 @@ class Target:
             h = layer(h, mask, c)
             if i in tapset:
                 captured.append(h)
-        return mm.norm(h), (mx.concatenate(captured, axis=-1) if tap is not None else None)
+        hn = mm.norm(h)
+        return hn, _captured(tap, captured, hn)
 
     def _body_hybrid(self, ids, cache, tap):
         """Replicates mlx-lm's hybrid text forward (qwen3_5-style: per-layer fa/ssm mask
@@ -133,7 +161,7 @@ class Target:
         from mlx_lm.models.base import create_attention_mask, create_ssm_mask
 
         mm = self._inner.model
-        tapset = set(tap) if tap is not None else ()
+        tapset = _tapset(tap)
         h = mm.embed_tokens(ids)
         fa_mask = create_attention_mask(h, cache[mm.fa_idx])
         ssm_mask = create_ssm_mask(h, cache[mm.ssm_idx])
@@ -142,7 +170,8 @@ class Target:
             h = layer(h, mask=(ssm_mask if layer.is_linear else fa_mask), cache=c)
             if i in tapset:
                 captured.append(h)
-        return mm.norm(h), (mx.concatenate(captured, axis=-1) if tap is not None else None)
+        hn = mm.norm(h)
+        return hn, _captured(tap, captured, hn)
 
     def _body_nemotron(self, ids, cache, tap):
         """Replicates mlx-lm's Nemotron-H forward (hybrid Mamba-2 / attention / MoE / MLP)
@@ -154,7 +183,7 @@ class Target:
         from mlx_lm.models.base import create_attention_mask, create_ssm_mask
 
         bb = self._inner.backbone
-        tapset = set(tap) if tap is not None else ()
+        tapset = _tapset(tap)
         h = bb.embeddings(ids)
         attn_mask = create_attention_mask(h, cache[bb.fa_idx])
         ssm_mask = create_ssm_mask(h, cache[bb.ssm_idx])
@@ -170,7 +199,8 @@ class Target:
             h = layer(h, mask=mask, cache=c)
             if i in tapset:
                 captured.append(h)
-        return bb.norm_f(h), (mx.concatenate(captured, axis=-1) if tap is not None else None)
+        hn = bb.norm_f(h)
+        return hn, _captured(tap, captured, hn)
 
     def _run_nemotron(self, ids, cache, tap):
         hn, fused = self._body_nemotron(ids, cache, tap)
@@ -200,7 +230,7 @@ class Target:
         from mlx_vlm.models.base import create_attention_mask
 
         tm = self.model.language_model.model   # muse_glimmer TextModel
-        tapset = set(tap) if tap is not None else ()
+        tapset = _tapset(tap)
         h = tm.embed_norm(tm.embed_tokens(ids))
         full_mask = create_attention_mask(h, cache[tm.full_attention_idx])
         sliding_mask = (create_attention_mask(h, cache[tm.sliding_attention_idx],
@@ -212,7 +242,8 @@ class Target:
             h = layer(h, mask=mask, cache=c)
             if i in tapset:
                 captured.append(h)
-        return tm.norm(h), (mx.concatenate(captured, axis=-1) if tap is not None else None)
+        hn = tm.norm(h)
+        return hn, _captured(tap, captured, hn)
 
     def _head_muse_glimmer(self, hn):
         """Project post-norm hidden -> logits with muse_glimmer's head: lm_head, scaled by

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -1,0 +1,182 @@
+"""Model-free tests for the native-MTP drafter.
+
+The properties worth pinning here are not "does it run" — they are the two that decide
+whether MTP can share the prefix cache at all:
+
+  1. the context is a **pure function of the committed prefix** (same tokens in, same
+     rows out, regardless of how the calls were chunked), and
+  2. the context **trims exactly**, so a restore at an earlier position is the state a
+     cold run would have produced.
+
+Both are what ``prefix_cache`` already assumes of the DSpark drafter context. If either
+breaks, MTP still generates correct output (the target verifies every token) — it just
+silently stops reusing prompts, which is the whole reason to prefer it over a runtime
+that restores from a block boundary. So these are the tests that would catch the
+regression that matters.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from mlx_dspark.model import CtxCache
+from mlx_dspark.mtp_model import MTPConfig, MTPDrafter
+
+H = 32
+VOCAB = 61
+
+
+def _cfg() -> MTPConfig:
+    return MTPConfig(hidden_size=H, num_attention_heads=4, num_key_value_heads=2,
+                     head_dim=8, intermediate_size=64, max_depth=3)
+
+
+def _drafter(seed: int = 0) -> MTPDrafter:
+    mx.random.seed(seed)
+    d = MTPDrafter(_cfg())
+    mx.eval(d.parameters())
+    # stand-ins for the target's embed_tokens / lm_head, which MTP does not ship
+    emb = mx.random.normal((VOCAB, H))
+    head = mx.random.normal((H, VOCAB))
+    mx.eval(emb, head)
+    d.bind_embed(lambda ids: emb[ids])
+    d.bind_lm_head(lambda h: h @ head)
+    return d
+
+
+def _hiddens(n: int, seed: int = 7) -> mx.array:
+    mx.random.seed(seed)
+    h = mx.random.normal((1, n, H))
+    mx.eval(h)
+    return h
+
+
+def test_context_length_is_one_behind_the_committed_tokens():
+    """MTP row ``t`` fuses ``(hidden_t, embed(x_{t+1}))``, so the newest hidden has no
+    partner yet. Pinning the ``N-1`` invariant matters because the prefix cache stores
+    the context next to a token count: if the two ever disagree by a variable amount, a
+    restore silently reuses rows that belong to a different position."""
+    d = _drafter()
+    ctx = d.make_ctx_cache()
+    tokens = [3, 9, 14, 2, 55]
+    d.update_context(_hiddens(len(tokens)), 0, ctx, token_ids=tokens)
+    assert ctx[0].length == len(tokens) - 1 == d.ctx_len_for(len(tokens))
+
+
+def test_chunked_prefill_matches_one_shot():
+    """The prefill feeds the drafter in chunks so long prompts never materialise every
+    fused state at once, and a resumed request feeds the suffix alone. Both must land on
+    the byte-identical context a single call would have built — otherwise reuse changes
+    the draft distribution, which shows up as a quiet acceptance drop rather than a
+    failure."""
+    tokens = [5, 12, 40, 7, 33, 21, 8]
+    hid = _hiddens(len(tokens))
+
+    one = _drafter()
+    ctx_one = one.make_ctx_cache()
+    one.update_context(hid, 0, ctx_one, token_ids=tokens)
+
+    split = _drafter()
+    ctx_split = split.make_ctx_cache()
+    cut = 3
+    split.update_context(hid[:, :cut, :], 0, ctx_split, token_ids=tokens[:cut])
+    split.update_context(hid[:, cut:, :], cut, ctx_split, token_ids=tokens[cut:])
+
+    assert ctx_split[0].length == ctx_one[0].length
+    mx.eval(ctx_one[0].k, ctx_split[0].k)
+    assert mx.allclose(ctx_one[0].k, ctx_split[0].k, atol=1e-5)
+    assert mx.allclose(ctx_one[0].v, ctx_split[0].v, atol=1e-5)
+
+
+def test_trim_to_equals_a_shorter_prefill():
+    """Trimming back to a shared prefix must equal having only ever seen that prefix —
+    this is the exactness claim ``prefix_cache`` makes when it reuses a conversation, and
+    it holds only because the MTP layer is full attention (position-local K/V rows) and
+    not one of the trunk's recurrent layers."""
+    tokens = [4, 18, 27, 6, 11, 44]
+    hid = _hiddens(len(tokens))
+    keep = 3
+
+    full = _drafter()
+    ctx_full = full.make_ctx_cache()
+    full.update_context(hid, 0, ctx_full, token_ids=tokens)
+    ctx_full[0].trim_to(keep)
+
+    short = _drafter()
+    ctx_short = short.make_ctx_cache()
+    short.update_context(hid[:, : keep + 1, :], 0, ctx_short, token_ids=tokens[: keep + 1])
+
+    assert ctx_short[0].length == keep
+    mx.eval(ctx_full[0].k, ctx_short[0].k)
+    assert mx.allclose(ctx_full[0].k, ctx_short[0].k, atol=1e-5)
+    assert mx.allclose(ctx_full[0].v, ctx_short[0].v, atol=1e-5)
+
+
+def test_context_snapshot_shape_matches_what_prefix_cache_stores():
+    """``prefix_cache._snapshot`` stores a drafter context as ``[(c.k, c.v), …]`` and
+    restores by trimming. Assert the MTP context is that same shape so it rides the
+    existing machinery instead of needing a second cache format — the difference between
+    a drafter that joins prefix reuse and one that has to disable it."""
+    d = _drafter()
+    ctx = d.make_ctx_cache()
+    d.update_context(_hiddens(4), 0, ctx, token_ids=[1, 2, 3, 4])
+    assert all(isinstance(c, CtxCache) for c in ctx)
+    snap = [(c.k, c.v) for c in ctx]
+    assert len(snap) == 1 and all(k is not None and v is not None for k, v in snap)
+
+
+def test_drafting_leaves_the_committed_context_untouched():
+    """Draft rows are speculative: they are appended to the same cache so each depth can
+    attend to the ones before it, then trimmed. If they survived, the context would
+    depend on tokens the target never accepted — the state would stop being a function
+    of the committed prefix and every later restore would be wrong."""
+    d = _drafter()
+    ctx = d.make_ctx_cache()
+    tokens = [2, 19, 31, 5]
+    d.update_context(_hiddens(len(tokens)), 0, ctx, token_ids=tokens)
+    before_len = ctx[0].length
+    before_k = ctx[0].k
+
+    draft, q = d.draft_block(pending=7, n_cached=len(tokens), ctx_caches=ctx, cap=3)
+    mx.eval(draft)
+
+    assert draft.shape == (3,)
+    assert q is None                       # greedy path proposes deterministically
+    assert ctx[0].length == before_len
+    assert mx.allclose(ctx[0].k, before_k, atol=1e-6)
+
+
+def test_draft_respects_cap_and_max_depth():
+    """The cap is the loop's per-round budget and ``max_depth`` the head's ceiling;
+    drafting past either wastes verify width on tokens measured to accept ~18% of the
+    time. Speed-only — the target still verifies whatever is proposed."""
+    d = _drafter()
+    ctx = d.make_ctx_cache()
+    d.update_context(_hiddens(3), 0, ctx, token_ids=[1, 2, 3])
+    assert d.draft_block(4, 3, ctx, cap=1)[0].shape == (1,)
+    assert d.draft_block(4, 3, ctx, cap=99)[0].shape == (d.config.max_depth,)
+
+
+def test_sampled_drafts_report_their_proposal_distribution():
+    """``temperature > 0`` uses the paper's accept rule ``min(1, p/q)``, so the loop needs
+    the same ``q`` the token was drawn from. Returning ``q`` from the rollout — rather
+    than letting the caller re-derive it — is what keeps sampling lossless at depth."""
+    d = _drafter()
+    ctx = d.make_ctx_cache()
+    d.update_context(_hiddens(3), 0, ctx, token_ids=[1, 2, 3])
+    draft, q = d.draft_block(4, 3, ctx, cap=3, temperature=0.8)
+    mx.eval(draft, q)
+    assert q.shape == (3, VOCAB)
+    sums = q.sum(axis=-1)
+    assert mx.allclose(sums, mx.ones_like(sums), atol=1e-4)
+
+
+def test_context_requires_tokens():
+    """The DSpark drafter's context is built from hidden states alone; MTP additionally
+    needs the next token at each position. Failing loudly beats silently fusing against
+    a zero embedding, which would draft plausibly and accept far less."""
+    d = _drafter()
+    ctx = d.make_ctx_cache()
+    with pytest.raises(ValueError):
+        d.update_context(_hiddens(3), 0, ctx, token_ids=None)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -44,6 +44,7 @@ class _FakeEngine:
         self.tokenizer = _FakeTok()
         self.calls = []
         self.response_text = "Hello world from mlx dspark"
+        self.reused_tokens = 0        # prompt tokens a prefix-cache hit would serve
 
     def generate(self, prompt_ids, *, max_tokens, temperature, top_p=1.0, top_k=0,
                  presence_penalty=0.0, frequency_penalty=0.0, logprobs=None,
@@ -63,7 +64,8 @@ class _FakeEngine:
                    "top": [(t, -0.5)] if logprobs else []} for t in [1, 2, 3, 4, 5]]
         return GenResult(text=text, token_ids=[1, 2, 3, 4, 5], num_tokens=5, num_rounds=2,
                          accept_lengths=[2, 3], target_forwards=2, seconds=0.1,
-                         finish_reason="stop", logprobs=lp)
+                         finish_reason="stop", logprobs=lp,
+                         reused_tokens=self.reused_tokens)
 
     def spec_info(self, res):
         return {"mode": self.mode, "accept_len": res.mean_accept_len,
@@ -137,6 +139,45 @@ def test_chat_stream_sse(server):
     assert content == "Hello world from mlx dspark "
     assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
     assert chunks[-1]["usage"]["completion_tokens"] == 5
+
+
+def test_usage_reports_cached_tokens(server):
+    """A prefix-cache hit is visible to the client, in the OpenAI shape.
+
+    Without it a caller can see that a request was fast but not whether it was
+    fast *because* the cache held — which is the difference between measuring
+    the cache and guessing at it.
+    """
+    eng, base = server
+    eng.reused_tokens = 0
+    c = _post(base, "/v1/chat/completions",
+              {"model": "x", "messages": [{"role": "user", "content": "hi"}]})
+    assert c["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
+
+    eng.reused_tokens = 7
+    c = _post(base, "/v1/chat/completions",
+              {"model": "x", "messages": [{"role": "user", "content": "hi"}]})
+    assert c["usage"]["prompt_tokens_details"]["cached_tokens"] == 7
+
+
+def test_stream_usage_reports_cached_tokens(server):
+    """Same field on the streamed final chunk, where clients actually read it."""
+    eng, base = server
+    eng.reused_tokens = 5
+    sse = _post(base, "/v1/chat/completions",
+                {"messages": [{"role": "user", "content": "hi"}], "stream": True,
+                 "stream_options": {"include_usage": True}}, stream=True)
+    chunks = [json.loads(l[6:]) for l in sse.split("\n\n")
+              if l.startswith("data: ") and l != "data: [DONE]"]
+    assert chunks[-1]["usage"]["prompt_tokens_details"]["cached_tokens"] == 5
+
+
+def test_completions_usage_reports_cached_tokens(server):
+    """/v1/completions shares the usage builder, so it reports it too."""
+    eng, base = server
+    eng.reused_tokens = 3
+    c = _post(base, "/v1/completions", {"model": "x", "prompt": "hi"})
+    assert c["usage"]["prompt_tokens_details"]["cached_tokens"] == 3
 
 
 def test_stop_forwarded(server):


### PR DESCRIPTION
Follow-up to #7 and #9. This is a **reference implementation, not a merge request** — please rewrite or discard whatever does not fit. You know this code; I have read it once.

**What it does**

Adds a fifth mode that drafts from Qwen's own MTP head (the 15 `mtp.*` tensors that ship inside the base checkpoint) instead of a separately distilled drafter, while keeping the token-level prefix reuse from #7.

The point is the combination. In #7 I reported that a native-MTP runtime decodes ~1.65x faster than mlx-dspark on my workload but loses on time-to-first-token because it restores from a 512-token block boundary. Drafting from the MTP head *inside* mlx-dspark gets both:

| at ~1400–1500 tokens of history | TTFT | time to first spoken chunk |
|---|---|---|
| `--mode dspark` | 336–374ms | 604–754ms |
| **`--mode mtp`** | **359–388ms** | **547–613ms** |
| the separate MTP runtime | 647–708ms | 647–842ms |

40-turn soak, same machine, Qwen3.8-27B-8bit, a 545-token Japanese system prompt, thinking off:

| | dspark | **mtp** |
|---|---|---|
| TTFT first 10 → last 10 turns | 330 → 330ms | 321 → 366ms |
| tok/s first 10 → last 10 | 19.4 → 23.4 | 29.2 → 23.4 |
| cached at turn 40 | 2674 / 2701 | 2645 / 2673 |
| resident | 27.6 GB | 28.4 GB |
| completed / reasoning leaks | 40/40 / 0 | 40/40 / 0 |

Tokens committed per verify round: 1.38 (dspark, cap 4) vs 2.00–3.12 (mtp, depth 3). Measured per-depth acceptance is [0.70, 0.29, 0.18], well under the 0.98/0.94 the published MTP model cards claim — presumably measured on different content — and it still wins.

**Why it fits without a second engine**

The MTP layer is *full* attention, not one of the trunk's 48 `linear_attention` layers. So its K/V rows are position-local and trim exactly — the same property `prefix_cache` already relies on for the DSpark drafter context, and the reason this reuses `CtxCache` verbatim rather than adding a cache shape. It is explicitly **not** routed into the `mode == "dflash"` branch that disables prefix caching; that branch is what would have thrown away the advantage.

Verification and acceptance are untouched. The head only changes how a draft is produced, so `lookup`, penalties, logprobs, stop strings, the cap controller and the prefix-cache hooks are all shared rather than reimplemented — the sequential rollout is one `elif` in `speculative_generate`.

**Shape of the change**

- `mtp_model.py` (new): the `mtp.` block — `fc` fusing `concat(embedding, hidden)`, one attention layer, the norms. Mirrors `Qwen3NextAttention` closely because its gated `q_proj` and partial rope both load cleanly while drafting badly if read as a plain GQA block.
- `generate.py`: an `elif drafter.sequential` draft branch, and `token_ids=` threaded to `update_context` (an MTP row fuses the *next* token at each position; `DSparkDrafter` accepts and ignores it).
- `target.py`: a `POST_NORM` tap sentinel. Every `_body_*` already computes `norm(h)` and throws it away — this returns it, so the tap costs the target nothing. Refused on mlx-vlm targets rather than handing the head the wrong tensor.
- `load.py`: `load_mtp()`, strict on tensor names for the same reason `load_drafter` is.
- `server.py` / `cli.py`: `--mode mtp`, `--mtp-depth` (default 3).

Weights come from the base Qwen repo, which ships the MTP block; `--drafter` points at a separate one for the MLX conversions that dropped it. Left in bf16 (~0.85 GB on Qwen3.8-27B).

**Correctness**

Output holds to the same standard the existing spec path does, and I want to be precise rather than overclaim: against a single-pass greedy run, `--mode mtp` diverged on 2 of 3 prompts — and **`--mode dspark` diverges at the identical index, to the identical token**, where the target's own top-2 logit gap is 0.125. That is the fp-tie case your docstrings already describe, not a difference introduced here.

**Tests**

`tests/test_mtp.py`, model-free in the existing style. The ones that matter pin the two properties that decide whether MTP can share the prefix cache at all: the context is a pure function of the committed prefix (chunked prefill == one-shot), and it trims exactly (trim-to-k == having only prefilled k). Both are what `prefix_cache` assumes. If either breaks, output stays correct and prompt reuse silently stops — so they are the regression worth catching.

Full suite: 474 passed. `test_bonsai.py::test_hybrid_full_accept_keeps_state` fails, identically on a clean checkout of the base commit (checked in a separate worktree) — unrelated. `ruff check` clean.

**Not done**

Batch engine and cap calibration are untouched, so `mtp` runs single-request with a fixed depth. mlx-vlm targets raise. If the direction is interesting to you I am happy to keep going, but I did not want to build more of it on guesses about how you would want it shaped.
