### PR TITLE
server: streamed Anthropic answers lose their last 20 characters — release the tool gate's lookahead at finish

### DIFF
--- a/src/mlx_dspark/anthropic_api.py
+++ b/src/mlx_dspark/anthropic_api.py
@@ -730,6 +730,14 @@ class MessageStream:
         sent = self.gate.sent_text
         if not sent:
             tail = cleaned
+        elif not self.gate.tripped:
+            # No marker ever fired, so the withheld lookahead is plain answer text — and
+            # ``cleaned`` can't reconcile it: parse_tool_calls strips its result, so it never
+            # startswith() a raw ``sent`` that leads with whitespace. Qwen3-style templates
+            # guarantee exactly that (the \n\n after the prefilled think-closer lands in its
+            # own round), and every streamed answer lost its final _MAX_MARKER - 1 characters
+            # while still reporting a clean stop and an accurate output_tokens.
+            tail = self.gate.buf[self.gate.sent:]
         elif cleaned.startswith(sent):
             tail = cleaned[len(sent):]
         else:

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -418,6 +418,29 @@ def test_stream_delivers_every_character_exactly_once():
     assert _streamed_text(ev) == "Hello world!"
 
 
+def test_stream_releases_the_held_back_tail_of_a_leading_whitespace_answer():
+    # The gate withholds _MAX_MARKER - 1 chars of lookahead; finish() must hand them back.
+    # parse_tool_calls strips its text, so reconciling against the raw sent prefix dropped
+    # the tail of any answer that reached the gate leading with whitespace.
+    body = "The quick brown fox jumps over the lazy dog."
+    ev = _drive(["\n\n" + body])
+    assert _assert_well_formed(ev) == {0: "text"}
+    assert _streamed_text(ev) == "\n\n" + body
+
+
+def test_stream_prefilled_thinking_answer_arrives_complete_one_char_at_a_time():
+    # The agent-shaped case: a Qwen3-style template prefills the <think> opener, the model
+    # emits the closer, and the \n\n that opens the answer lands in its own round — after
+    # the post-closer lstrip already ran — so the raw stream leads with whitespace.
+    st = A.MessageStream(model="m", input_tokens=1, in_thinking="</think>")
+    events = list(st.start())
+    for ch in "reasoning</think>\n\nSecond cousins once removed.":
+        events.extend(st.delta(ch))
+    events.extend(st.finish(finish_reason="stop", output_tokens=1))
+    assert _assert_well_formed(events) == {0: "thinking", 1: "text"}
+    assert _streamed_text(events).endswith("Second cousins once removed.")
+
+
 def test_stream_reports_usage_and_stop_reason():
     ev = _drive(["hi"], finish_reason="length", output_tokens=11)
     (delta,) = [d for n, d in ev if n == "message_delta"]


### PR DESCRIPTION
## Symptom

Streamed responses from the Anthropic-compatible endpoint end 20 characters
early, mid-word, with a clean `end_turn` and an accurate `output_tokens`. The
same request with `"stream": false` returns the complete text. Agent clients
like Claude Code stream every turn, so every turn is clipped.

Reproduced on Qwen3.8-27B-8bit served with `--mode baseline` and `--mode
dspark` alike, and confirmed by logging `GenResult.text` server-side against
the concatenated `text_delta`s a client receives. The server's text was
complete on every run; the client's was exactly `_MAX_MARKER - 1` = 20
characters short on every run.

## Root cause

`_ToolGate` withholds the last `_MAX_MARKER - 1` characters of the answer so a
tool-call marker split across two rounds is still caught. `MessageStream.finish`
is meant to hand that lookahead back, but it reconciles against the text from
`parse_tool_calls`, which returns `cleaned.strip()`, while `gate.sent_text` is
the raw stream prefix. Any answer that reaches the gate leading with whitespace
makes `cleaned.startswith(sent)` false, and `finish` takes its `tail = ""`
branch, dropping the held-back characters.

Qwen3-style templates guarantee the leading whitespace. The prompt prefills the
`<think>` opener, so the model emits only the closer, and the post-closer
`lstrip()` in `_consume` runs in the round where the buffer still ends at
`</think>`. The `\n\n` that opens the answer arrives in a later round and
reaches the gate raw.

## Fix

When the gate never tripped, no marker exists anywhere in the buffer, so the
withheld lookahead is plain answer text. `finish` now emits the raw unsent
suffix (`gate.buf[gate.sent:]`) in that case. Using the raw suffix rather than
re-parsing it also preserves a mid-sentence leading space in the tail, which
any `strip()`-based reconciliation would eat. The tripped path is unchanged.

## Tests

Two regressions in `tests/test_anthropic.py`, next to
`test_stream_delivers_every_character_exactly_once`, which passes today only
because its text is shorter than the holdback and whitespace-free:

- `test_stream_releases_the_held_back_tail_of_a_leading_whitespace_answer`
  drives a single whitespace-led chunk and asserts every character arrives.
- `test_stream_prefilled_thinking_answer_arrives_complete_one_char_at_a_time`
  drives the agent-shaped case (prefilled think opener, one character per
  round) and asserts the answer arrives complete.

Both fail on `main` and pass with the fix. `ruff check src tests` is clean and
the model-free suite passes (`tests/test_bonsai.py::test_hybrid_full_accept_keeps_state`
fails identically on unmodified `main` in my environment, so it's unrelated).
