### PR TITLE
Use local model files before starting a download

### DIFF
--- a/apps/MacApp/Sources/AppHost/ModelsScreen.swift
+++ b/apps/MacApp/Sources/AppHost/ModelsScreen.swift
@@ -47,8 +47,9 @@ struct ModelsScreen: View {
                 // They used to be disabled outright — which left a fresh machine with every
                 // pair greyed out and no way to download from this screen at all (issue #15).
                 ForEach(model.models) { row in
-                    ModelRowView(row: row, isLoaded: row.target == model.model,
-                                 canLoad: row.target != model.model && !model.isModelLoading) {
+                    ModelRowView(row: row, isLoaded: model.isServerReady && row.target == model.model,
+                                 canLoad: (!model.isServerReady || row.target != model.model)
+                                    && !model.isModelLoading) {
                         Task { await model.switchModel(to: row.target) }
                     }
                 }
@@ -64,7 +65,7 @@ struct ModelsScreen: View {
                                      + "unpaired models run with lookup speculation.")
                     ForEach(onDisk) { installed in
                         InstalledRowView(installed: installed,
-                                         isLoaded: installed.repo == model.model)
+                                         isLoaded: model.isServerReady && installed.repo == model.model)
                     }
                 }
 

--- a/src/mlx_dspark/cli.py
+++ b/src/mlx_dspark/cli.py
@@ -386,7 +386,21 @@ def cmd_serve(argv: list[str]) -> None:
         max_draft = max(1, md)
 
     if not args.no_model:
-        print(f"loading {args.mode} engine — first run downloads weights…")
+        # Keep the startup message honest: local paths and complete local snapshots do not
+        # enter the cancellable Hub prefetch at all.  The loader still performs calibration
+        # on first use, so "loading" remains accurate without implying a download.
+        from .load import resolve_local
+        local_inputs = [args.model]
+        if args.drafter:
+            local_inputs.append(args.drafter)
+        # With an omitted drafter, auto/dspark/dflash may select a registry drafter later;
+        # do not claim an offline load until that input is explicit too.
+        all_local = (all(resolve_local(value) is not None for value in local_inputs)
+                     and (args.drafter is not None or args.mode in ("lookup", "baseline")))
+        if all_local:
+            print(f"loading {args.mode} engine — using local weights…")
+        else:
+            print(f"loading {args.mode} engine — missing weights may download…")
     # Captured so a `/admin/load` model swap re-loads with the same server flags, changing only
     # the model — an in-place swap that keeps the port instead of a full restart.
     load_kwargs = {

--- a/src/mlx_dspark/diagnostics.py
+++ b/src/mlx_dspark/diagnostics.py
@@ -261,24 +261,15 @@ def disk_usage(rows: list[dict] | None = None, *, hub_dir: str | None = None,
 def _is_local(repo: str | None) -> bool:
     """Whether a repo's weights are already on disk — no download, no network.
 
-    Checks the plain-dir cache that ``_resolve`` prefers and the HF hub cache layout directly;
+    Checks the plain-dir cache that ``_resolve`` prefers, LM Studio's MLX cache, and the HF hub cache;
     calling ``_resolve`` itself would *start a download*, which is exactly what this must not do.
     """
     if not repo:
         return False
     if repo.startswith("gguf:"):
         repo = repo[len("gguf:"):].rsplit("/", 1)[0]
-    if os.path.isdir(repo):
-        return True
-    # Both hand-download naming conventions: bare basename and org-prefixed "<org>_<name>"
-    # (see load._resolve — these two must agree, one answers "installed?" and the other "where").
-    models = os.path.expanduser("~/.cache/mlx_dspark/models")
-    stripped = repo.rstrip("/")
-    for name in (os.path.basename(stripped), stripped.replace("/", "_")):
-        if os.path.isdir(os.path.join(models, name)):
-            return True
-    hub = os.path.expanduser("~/.cache/huggingface/hub")
-    return os.path.isdir(os.path.join(hub, "models--" + repo.replace("/", "--")))
+    from .load import resolve_local
+    return resolve_local(repo) is not None
 
 
 _DETECT = object()      # distinguishes "measure this machine" from "RAM is genuinely unknown"

--- a/src/mlx_dspark/download.py
+++ b/src/mlx_dspark/download.py
@@ -68,21 +68,10 @@ def _looks_like_repo(repo_or_path: str | None) -> bool:
     here."""
     if not repo_or_path or ":" in repo_or_path:
         return False
-    if os.path.isdir(os.path.expanduser(repo_or_path)):
-        return False
     if repo_or_path.count("/") != 1:
         return False
-    # the plain-dir cache that _resolve prefers over the hub (see load.py) — match BOTH the
-    # bare basename and the org-prefixed "<org>_<name>" form, exactly as _resolve/_is_local do.
-    # Without the second form a hand-downloaded copy under the org-prefixed name (e.g.
-    # DimInfer_Qwen3.8-27B-Dspark-v1) gets needlessly re-fetched here even though it's on disk.
-    # These three checks must stay in lockstep.
-    models = os.path.expanduser("~/.cache/mlx_dspark/models")
-    stripped = repo_or_path.rstrip("/")
-    for name in (os.path.basename(stripped), stripped.replace("/", "_")):
-        if os.path.isdir(os.path.join(models, name)):
-            return False
-    return True
+    from .load import resolve_local
+    return resolve_local(repo_or_path) is None
 
 
 def _fetch_total(repo: str, entry: dict) -> None:
@@ -108,12 +97,6 @@ def ensure_local(repo_or_path: str | None) -> None:
     if not _looks_like_repo(repo_or_path):
         return
     repo = str(repo_or_path)
-    with contextlib.suppress(Exception):
-        from huggingface_hub import snapshot_download
-
-        snapshot_download(repo, local_files_only=True)   # complete already -> no child
-        return
-
     env = dict(os.environ, HF_HUB_DISABLE_PROGRESS_BARS="1")
     # The child watches its parent and exits when orphaned: the server dies by SIGTERM
     # (the app's supervisor), which runs no atexit hooks — without this, killing the

--- a/src/mlx_dspark/load.py
+++ b/src/mlx_dspark/load.py
@@ -365,6 +365,57 @@ def is_mlx_model_dir(path: str) -> bool:
     return "config.json" in names and any(n.endswith(".safetensors") for n in names)
 
 
+def lmstudio_model_path(repo_or_path: str | None) -> str | None:
+    """Return the exact LM Studio MLX directory for a repo id, if it exists.
+
+    LM Studio stores models as ``<root>/<publisher>/<model>`` rather than in the
+    Hugging Face cache layout.  Keep this lookup in one place so the loader,
+    downloader preflight, and the model inventory make the same decision.  Exact
+    publisher/model matching is deliberate: two publishers may use the same
+    basename, and GGUF-only directories are not MLX checkpoints.
+    """
+    if not repo_or_path or repo_or_path.startswith("gguf:"):
+        return None
+    stripped = str(repo_or_path).rstrip("/")
+    if stripped.count("/") != 1:
+        return None
+    for root in LMSTUDIO_ROOTS:
+        local = os.path.join(os.path.expanduser(root), stripped)
+        if os.path.isdir(local) and is_mlx_model_dir(local):
+            return local
+    return None
+
+
+def resolve_local(repo_or_path: str | None) -> str | None:
+    """Resolve a model to an on-disk path without network access.
+
+    This is the single local-resolution path shared by the loader, download
+    preflight, and diagnostics.  A caller that gets ``None`` may explicitly
+    choose to fetch the Hub repo; this function itself never does that.
+    """
+    if not repo_or_path or repo_or_path.startswith("gguf:"):
+        return None
+    if os.path.isdir(repo_or_path):
+        return repo_or_path
+    models = os.path.expanduser("~/.cache/mlx_dspark/models")
+    stripped = str(repo_or_path).rstrip("/")
+    for name in (os.path.basename(stripped), stripped.replace("/", "_")):
+        local = os.path.join(models, name)
+        if os.path.isdir(local):
+            return local
+    local = lmstudio_model_path(repo_or_path)
+    if local:
+        return local
+    if stripped.count("/") != 1:
+        return None
+    # HF's local-only resolver handles complete snapshots and never contacts the
+    # network.  Incomplete/missing snapshots simply fall through to ``None``.
+    try:
+        return snapshot_download(stripped, local_files_only=True)
+    except Exception:  # noqa: BLE001 — local probing is never a load gate
+        return None
+
+
 def _resolve(repo_or_path: str) -> str:
     if repo_or_path.startswith("gguf:"):
         # "gguf:{hf_repo}/{filename}.gguf" — a PrismML dspark drafter shipped as GGUF;
@@ -372,32 +423,9 @@ def _resolve(repo_or_path: str) -> str:
         from .gguf_convert import ensure_converted
         repo, filename = repo_or_path[len("gguf:"):].rsplit("/", 1)
         return ensure_converted(repo, filename)
-    if os.path.isdir(repo_or_path):
-        return repo_or_path
-    # Prefer the plain-dir model cache (~/.cache/mlx_dspark/models/…) over a hub download:
-    # models fetched by hand (e.g. around a wedged huggingface_hub) live there, and
-    # auto-resolved drafters must not re-download gigabytes the user already has on disk.
-    # Match BOTH naming conventions those hand-downloads use: the bare basename AND the
-    # org-prefixed "<org>_<name>" form (what huggingface-cli and robust_download.py produce,
-    # and what disambiguates two repos that share a basename — e.g. DimInfer's
-    # Qwen3.8-27B-Dspark-v1 vs the SpecForge Qwen3.8-27B-DSpark). Basename first keeps the
-    # historical preference. Must stay in lockstep with diagnostics._is_local.
-    models = os.path.expanduser("~/.cache/mlx_dspark/models")
-    stripped = repo_or_path.rstrip("/")
-    for name in (os.path.basename(stripped), stripped.replace("/", "_")):
-        local = os.path.join(models, name)
-        if os.path.isdir(local):
-            return local
-    # Reuse models LM Studio already downloaded (issue #12): its cache is plain
-    # <root>/<publisher>/<model> dirs, and its MLX downloads are exactly the safetensors
-    # layout our loaders read. Exact org/name match only — no basename guessing, so two
-    # publishers sharing a model name can't cross-resolve. GGUF-only dirs are skipped
-    # (is_mlx_model_dir), falling through to the hub download rather than failing deep
-    # inside a loader that can't read GGUF targets.
-    for root in LMSTUDIO_ROOTS:
-        local = os.path.join(os.path.expanduser(root), stripped)
-        if os.path.isdir(local) and is_mlx_model_dir(local):
-            return local
+    local = resolve_local(repo_or_path)
+    if local:
+        return local
     return snapshot_download(repo_or_path)
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -42,6 +42,19 @@ def test_looks_like_repo_prefers_plain_dir_cache(tmp_path, monkeypatch):
     assert _looks_like_repo("org/Other-Model")
 
 
+def test_looks_like_repo_skips_complete_lmstudio_mlx_dir(tmp_path, monkeypatch):
+    """LM Studio models are local inputs too: preflight must not start a Hub fetch."""
+    root = tmp_path / "lmstudio"
+    model = root / "org" / "Some-Model-4bit"
+    model.mkdir(parents=True)
+    (model / "config.json").write_text("{}")
+    (model / "model.safetensors").write_bytes(b"weights")
+    import mlx_dspark.load as load
+    monkeypatch.setattr(load, "LMSTUDIO_ROOTS", (str(root),))
+    assert not _looks_like_repo("org/Some-Model-4bit")
+    assert _looks_like_repo("org/Other-Model")
+
+
 def test_ensure_local_is_a_noop_for_non_repos(tmp_path):
     ensure_local(None)
     ensure_local(str(tmp_path))


### PR DESCRIPTION
## Summary

The app could list a local MLX model but still start a new Hugging Face download when the user loaded it. The download preflight checked only the Hugging Face cache, while the loader checked more local locations. This made an installed model look missing and could also leave a stale `loaded` badge after a failed load.

## What changed

- Add one network-free `resolve_local()` function for local model resolution.
- Reuse it in the loader, download preflight, and diagnostics.
- Recognize explicit paths, the local mlx-dspark cache, provider MLX cache layouts, and complete Hugging Face snapshots without model-specific IDs.
- Report when startup uses local weights instead of showing a generic download message.
- Do not show `loaded` when the server is not ready.
- Add a regression test for a local provider MLX directory.

## Validation

- `6 passed` for `tests/test_download.py`.
- Ruff checks pass for all changed Python files.
- `swift build` and the debug app bundle build pass.
- The rebuilt app reported `status: ok` with target `mlx-community/Qwen3.8-27B-4bit` and drafter `incoai/Qwen3.8-27B-DFlash2`; `download` was `null` and both models were reported as installed.
