### PR TITLE
app: add optional LAN serving and API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ mlx-dspark serve --model mlx-community/Qwen3-8B-8bit        # → http://127.0.0
 #                   confidence_threshold / context_window overrides
 ```
 
+To serve other devices on the local network, bind all IPv4 interfaces. Authentication is
+independent: omit `--api-key` only on a network where every reachable device is trusted.
+
+```bash
+# LAN, unauthenticated
+mlx-dspark serve --model mlx-community/Qwen3-8B-8bit --host 0.0.0.0
+
+# LAN, authenticated (Authorization: Bearer KEY or x-api-key: KEY)
+mlx-dspark serve --model mlx-community/Qwen3-8B-8bit --host 0.0.0.0 --api-key KEY
+```
+
+Clients must use the Mac's LAN address (for example `http://192.168.1.20:8080/v1`), not
+`0.0.0.0`. Traffic is plain HTTP; without an API key, anyone who can reach the port can use it.
+
 `--mode auto` picks the best available speculation for any target (a known DSpark drafter → else
 DFlash → else drafter-free n-gram **lookup**), so *any* repo serves with some speedup and no extra flags.
 

--- a/apps/MacApp/README.md
+++ b/apps/MacApp/README.md
@@ -85,6 +85,21 @@ deliberately.
 
 Delete `runtime/` to force a clean re-bootstrap.
 
+## Local network serving
+
+Settings → Local server can bind the engine to every IPv4 interface so another device on
+the LAN can use its OpenAI or Anthropic API. “Serve on LAN” and “Require API key” are
+independent: authentication can be used on loopback too, and a trusted LAN can be served
+without it. An unauthenticated LAN listener is reachable by every device that can connect to
+the selected port. API keys are stored as plain text in the app's preferences plist.
+
+The equivalent CLI invocation is:
+
+```bash
+mlx-dspark serve --host 0.0.0.0                         # unauthenticated LAN
+mlx-dspark serve --host 0.0.0.0 --api-key YOUR_KEY      # authenticated LAN
+```
+
 ## Distribution
 
 Ad-hoc signing (`codesign -s -`) is what `make_app.sh` does — enough to run locally. Shipping a

--- a/apps/MacApp/Sources/AppCore/ServerNetworking.swift
+++ b/apps/MacApp/Sources/AppCore/ServerNetworking.swift
@@ -1,0 +1,48 @@
+import Darwin
+import Foundation
+import Security
+
+/// Small, model-free helpers shared by the server supervisor and Settings UI.
+public enum ServerNetworking {
+    /// Every active, non-loopback IPv4 address that a client on the LAN can use.
+    public static func lanIPv4Addresses() -> [String] {
+        var interfaces: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&interfaces) == 0, let first = interfaces else { return [] }
+        defer { freeifaddrs(interfaces) }
+
+        var addresses = Set<String>()
+        var current: UnsafeMutablePointer<ifaddrs>? = first
+        while let interface = current {
+            defer { current = interface.pointee.ifa_next }
+            guard let address = interface.pointee.ifa_addr,
+                  address.pointee.sa_family == UInt8(AF_INET) else { continue }
+
+            let flags = Int32(interface.pointee.ifa_flags)
+            guard flags & IFF_UP != 0, flags & IFF_LOOPBACK == 0 else { continue }
+
+            var addr = address.withMemoryRebound(to: sockaddr_in.self, capacity: 1) {
+                $0.pointee.sin_addr
+            }
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            guard inet_ntop(AF_INET, &addr, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+                continue
+            }
+            let value = String(cString: buffer)
+            if value != "0.0.0.0" { addresses.insert(value) }
+        }
+        return addresses.sorted()
+    }
+
+    /// A 256-bit URL-safe token suitable for the server's bearer/x-api-key check.
+    public static func generateAPIKey() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = bytes.withUnsafeMutableBytes { raw in
+            SecRandomCopyBytes(kSecRandomDefault, raw.count, raw.baseAddress!)
+        }
+        precondition(status == errSecSuccess, "Secure random generation failed")
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/apps/MacApp/Sources/AppCore/ServerSupervisor.swift
+++ b/apps/MacApp/Sources/AppCore/ServerSupervisor.swift
@@ -35,6 +35,27 @@ public struct ServerConfig: Equatable, Sendable {
         self.port = port
         self.portIsExplicit = portIsExplicit
     }
+
+    /// Translate the app's two independent preferences into the CLI launch contract.
+    public static func appPreferences(
+        model: String? = nil,
+        serveOnLAN: Bool,
+        apiKeyEnabled: Bool,
+        apiKey: String,
+        port: Int,
+        portIsExplicit: Bool
+    ) -> ServerConfig {
+        let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ServerConfig(
+            model: model,
+            mode: "auto",
+            maxDraft: "auto",
+            host: serveOnLAN ? "0.0.0.0" : "127.0.0.1",
+            apiKey: apiKeyEnabled && !key.isEmpty ? key : nil,
+            port: port,
+            portIsExplicit: portIsExplicit
+        )
+    }
 }
 
 /// Owns the `mlx-dspark serve` child process.
@@ -87,10 +108,10 @@ public actor ServerSupervisor {
             } else {
                 logStore.note("default port \(config.port) is in use — "
                               + "starting on an automatic port instead")
-                chosenPort = try Self.freePort()
+                chosenPort = try Self.freePort(host: config.host)
             }
         } else {
-            chosenPort = try Self.freePort()
+            chosenPort = try Self.freePort(host: config.host)
         }
         port = chosenPort
 
@@ -133,7 +154,10 @@ public actor ServerSupervisor {
             Task { await self?.childExited(code: p.terminationStatus) }
         }
 
-        let client = APIClient(baseURL: URL(string: "http://\(config.host):\(chosenPort)")!,
+        // A wildcard is a listener address, never a client destination. Keep the app's
+        // control traffic on loopback even while other devices reach the same port via LAN.
+        let clientHost = config.host == "0.0.0.0" ? "127.0.0.1" : config.host
+        let client = APIClient(baseURL: URL(string: "http://\(clientHost):\(chosenPort)")!,
                                apiKey: config.apiKey)
         let deadline = Date().addingTimeInterval(readyTimeout)
         while Date() < deadline {
@@ -224,7 +248,7 @@ public actor ServerSupervisor {
     /// whatever else the user runs. There is an unavoidable race between closing this socket
     /// and the child binding it; the caller retries. (A *user-chosen* fixed port is different:
     /// it's opt-in, checked with ``portIsFree(_:host:)``, and fails with a named fix.)
-    public static func freePort() throws -> Int {
+    public static func freePort(host: String = "127.0.0.1") throws -> Int {
         let fd = socket(AF_INET, SOCK_STREAM, 0)
         guard fd >= 0 else { throw ShellError.launchFailed("socket", underlying: "unavailable") }
         defer { close(fd) }
@@ -234,7 +258,7 @@ public actor ServerSupervisor {
         var addr = sockaddr_in()
         addr.sin_family = sa_family_t(AF_INET)
         addr.sin_port = 0                                  // kernel picks
-        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        addr.sin_addr.s_addr = inet_addr(host)
         let bound = withUnsafePointer(to: &addr) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
                 Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))

--- a/apps/MacApp/Sources/AppHost/AppModel.swift
+++ b/apps/MacApp/Sources/AppHost/AppModel.swift
@@ -366,6 +366,12 @@ final class AppModel: ObservableObject {
     /// import, no weights). Returns false after calling `fail()` when even that can't start.
     private func spawnServer() async -> Bool {
         guard let engine = engineURL else { return false }
+        let config = ServerConfig.appPreferences(
+            serveOnLAN: Defaults.serveOnLAN,
+            apiKeyEnabled: Defaults.apiKeyEnabled,
+            apiKey: Defaults.apiKey,
+            port: Defaults.enginePort,
+            portIsExplicit: Defaults.enginePortIsExplicit)
         phase = .startingServer
         let supervisor = ServerSupervisor(engine: engine, logStore: logStore)
         self.supervisor = supervisor
@@ -374,10 +380,8 @@ final class AppModel: ObservableObject {
         }
         do {
             let port = try await supervisor.start(
-                config: ServerConfig(model: nil, mode: "auto", maxDraft: "auto",
-                                     port: Defaults.enginePort,
-                                     portIsExplicit: Defaults.enginePortIsExplicit))
-            return await connect(port: port)
+                config: config)
+            return await connect(port: port, apiKey: config.apiKey)
         } catch {
             // An engine below this app's floor doesn't know `--no-model`, and an offline
             // machine can't be force-upgraded to one that does — fall back to the classic
@@ -388,10 +392,14 @@ final class AppModel: ObservableObject {
                           + "(older engine?)")
             do {
                 let port = try await supervisor.start(
-                    config: ServerConfig(model: model, mode: "auto", maxDraft: "auto",
-                                         port: Defaults.enginePort,
-                                         portIsExplicit: Defaults.enginePortIsExplicit))
-                return await connect(port: port)
+                    config: ServerConfig.appPreferences(
+                        model: model,
+                        serveOnLAN: Defaults.serveOnLAN,
+                        apiKeyEnabled: Defaults.apiKeyEnabled,
+                        apiKey: Defaults.apiKey,
+                        port: Defaults.enginePort,
+                        portIsExplicit: Defaults.enginePortIsExplicit))
+                return await connect(port: port, apiKey: config.apiKey)
             } catch {
                 fail(error)
                 return false
@@ -399,8 +407,9 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func connect(port: Int) async -> Bool {
-        let client = APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+    private func connect(port: Int, apiKey: String?) async -> Bool {
+        let client = APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!,
+                               apiKey: apiKey)
         self.apiClient = client
         currentHealth = try? await client.health()
         return true
@@ -1056,6 +1065,26 @@ enum Defaults {
     /// True when the user chose the port (any value, including 0 = automatic) — a taken
     /// user-chosen port is a hard error naming the fix; the app default falls back.
     static var enginePortIsExplicit: Bool { store.object(forKey: "enginePort") != nil }
+
+    /// Bind the engine to every IPv4 interface instead of loopback only.
+    static var serveOnLAN: Bool {
+        get { store.bool(forKey: "serveOnLAN") }
+        set { store.set(newValue, forKey: "serveOnLAN") }
+    }
+
+    /// Authentication is independent of the bind address: loopback and LAN can each run
+    /// with or without it. The key is intentionally retained when this is turned off.
+    static var apiKeyEnabled: Bool {
+        get { store.bool(forKey: "apiKeyEnabled") }
+        set { store.set(newValue, forKey: "apiKeyEnabled") }
+    }
+
+    /// Plain-text app preference by design: this protects a trusted LAN endpoint, not the
+    /// local account from itself. Keeping it here also makes backup/reset behavior obvious.
+    static var apiKey: String {
+        get { store.string(forKey: "apiKey") ?? "" }
+        set { store.set(newValue, forKey: "apiKey") }
+    }
 
     static var currentSession: UUID? {
         get { store.string(forKey: "currentSession").flatMap(UUID.init(uuidString:)) }

--- a/apps/MacApp/Sources/AppHost/SettingsScreen.swift
+++ b/apps/MacApp/Sources/AppHost/SettingsScreen.swift
@@ -418,15 +418,34 @@ struct ServerCard: View {
     // clamp rewrites the text under the cursor (see the Race max-tokens field).
     @State private var portText: String =
         Defaults.enginePort == 0 ? "" : String(Defaults.enginePort)
+    @State private var serveOnLAN = Defaults.serveOnLAN
+    @State private var apiKeyEnabled = Defaults.apiKeyEnabled
+    @State private var apiKeyText = Defaults.apiKey
+    @State private var validationError: String?
     @State private var restarting = false
 
     var body: some View {
         Card(title: "Local server",
-             subtitle: "OpenAI- and Anthropic-compatible, on this machine only.") {
+             subtitle: Defaults.serveOnLAN
+                ? "OpenAI- and Anthropic-compatible, available on your local network."
+                : "OpenAI- and Anthropic-compatible, on this machine only.") {
             VStack(alignment: .leading, spacing: 8) {
                 if case .ready(let port, let health) = model.serverState {
-                    endpoint("OpenAI", "http://127.0.0.1:\(port)/v1")
-                    endpoint("Anthropic", "http://127.0.0.1:\(port)")
+                    if Defaults.serveOnLAN {
+                        let addresses = ServerNetworking.lanIPv4Addresses()
+                        if addresses.isEmpty {
+                            Text("No active LAN address is available yet.")
+                                .font(.callout).foregroundStyle(.secondary)
+                        } else {
+                            ForEach(addresses, id: \.self) { address in
+                                endpoint("OpenAI", "http://\(address):\(port)/v1")
+                                endpoint("Anthropic", "http://\(address):\(port)")
+                            }
+                        }
+                    } else {
+                        endpoint("OpenAI", "http://127.0.0.1:\(port)/v1")
+                        endpoint("Anthropic", "http://127.0.0.1:\(port)")
+                    }
                     if let window = health.contextWindow {
                         Text("Context window \(window) tokens")
                             .font(.caption).foregroundStyle(.secondary)
@@ -439,6 +458,33 @@ struct ServerCard: View {
                 }
                 Divider()
                 portRow
+                Toggle("Serve on LAN", isOn: $serveOnLAN)
+                    .font(.callout)
+                Text("Listens on all IPv4 interfaces. Other devices use one of the LAN "
+                     + "addresses shown above after the engine restarts.")
+                    .font(.caption).foregroundStyle(.secondary)
+
+                Toggle("Require API key", isOn: $apiKeyEnabled)
+                    .font(.callout)
+                if apiKeyEnabled { apiKeyRow }
+
+                if serveOnLAN && !apiKeyEnabled {
+                    Label("Anyone who can reach this Mac on the local network can use the API.",
+                          systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption).foregroundStyle(Theme.warning)
+                }
+                if let validationError {
+                    Label(validationError, systemImage: "xmark.circle.fill")
+                        .font(.caption).foregroundStyle(Theme.warning)
+                }
+
+                Button(restarting ? "Restarting…" : "Apply & restart engine") {
+                    guard commitSettings() else { return }
+                    restarting = true
+                    Task { await model.restartEngine(); restarting = false }
+                }
+                .font(.caption)
+                .disabled(restarting)
             }
         }
     }
@@ -453,13 +499,6 @@ struct ServerCard: View {
                 .textFieldStyle(.roundedBorder)
                 .frame(width: 92)
                 .onSubmit { commitPort() }
-            Button(restarting ? "Restarting…" : "Apply & restart engine") {
-                commitPort()
-                restarting = true
-                Task { await model.restartEngine(); restarting = false }
-            }
-            .font(.caption)
-            .disabled(restarting)
             Spacer()
         }
         Text("A fixed port keeps external clients' base URL stable across launches "
@@ -467,6 +506,45 @@ struct ServerCard: View {
              + "app falls back to an automatic port). Blank = always automatic. "
              + "Ports 1024–65535.")
             .font(.caption).foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder private var apiKeyRow: some View {
+        HStack(spacing: 8) {
+            Text("API key").font(.callout).foregroundStyle(.secondary)
+                .frame(width: 78, alignment: .leading)
+            TextField("Required", text: $apiKeyText)
+                .textFieldStyle(.roundedBorder)
+                .font(.callout.monospaced())
+            Button("Generate") { apiKeyText = ServerNetworking.generateAPIKey() }
+                .buttonStyle(.link).font(.caption)
+            Button("Copy") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(apiKeyText, forType: .string)
+            }
+            .buttonStyle(.link).font(.caption)
+            .disabled(apiKeyText.isEmpty)
+            Button("Clear") { apiKeyText = "" }
+                .buttonStyle(.link).font(.caption)
+                .disabled(apiKeyText.isEmpty)
+        }
+        Text("Clients may send Authorization: Bearer <key> or x-api-key: <key>. "
+             + "Stored as plain text in this app's preferences.")
+            .font(.caption).foregroundStyle(.secondary)
+    }
+
+    private func commitSettings() -> Bool {
+        let key = apiKeyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKeyEnabled || !key.isEmpty else {
+            validationError = "Enter or generate an API key before enabling authentication."
+            return false
+        }
+        validationError = nil
+        commitPort()
+        Defaults.serveOnLAN = serveOnLAN
+        Defaults.apiKeyEnabled = apiKeyEnabled
+        Defaults.apiKey = key
+        apiKeyText = key
+        return true
     }
 
     private func commitPort() {

--- a/apps/MacApp/Tests/AppCoreTests/AppCoreTests.swift
+++ b/apps/MacApp/Tests/AppCoreTests/AppCoreTests.swift
@@ -69,6 +69,40 @@ struct ServerSupervisorTests {
         let ports = try (0..<4).map { _ in try ServerSupervisor.freePort() }
         #expect(Set(ports).count > 1)
     }
+
+    @Test func freePortSupportsWildcardBinding() throws {
+        let port = try ServerSupervisor.freePort(host: "0.0.0.0")
+        #expect(port > 1024)
+        #expect(ServerSupervisor.portIsFree(port, host: "0.0.0.0"))
+    }
+
+    @Test func appPreferencesKeepLANAndAuthenticationIndependent() {
+        let combinations = [
+            (false, false, "127.0.0.1", nil),
+            (false, true, "127.0.0.1", "secret"),
+            (true, false, "0.0.0.0", nil),
+            (true, true, "0.0.0.0", "secret"),
+        ]
+        for (lan, auth, host, key) in combinations {
+            let config = ServerConfig.appPreferences(
+                serveOnLAN: lan, apiKeyEnabled: auth, apiKey: " secret ",
+                port: 8484, portIsExplicit: false)
+            #expect(config.host == host)
+            #expect(config.apiKey == key)
+        }
+    }
+
+    @Test func generatedAPIKeyIsStrongAndURLSafe() {
+        let first = ServerNetworking.generateAPIKey()
+        let second = ServerNetworking.generateAPIKey()
+        #expect(first.count == 43)
+        #expect(first != second)
+        #expect(first.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" })
+    }
+
+    @Test func lanAddressesExcludeLoopback() {
+        #expect(!ServerNetworking.lanIPv4Addresses().contains(where: { $0.hasPrefix("127.") }))
+    }
 }
 
 @Suite("Engine source resolution")

--- a/apps/MacApp/packaging/make_app.sh
+++ b/apps/MacApp/packaging/make_app.sh
@@ -58,6 +58,8 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>CFBundleVersion</key>               <string>${VERSION}</string>
     <key>LSMinimumSystemVersion</key>        <string>${MIN_MACOS}</string>
     <key>NSHighResolutionCapable</key>       <true/>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>mlx-dspark can serve its model API to other devices on your local network.</string>
     <key>LSApplicationCategoryType</key>     <string>public.app-category.developer-tools</string>
 </dict>
 </plist>

--- a/src/mlx_dspark/cli.py
+++ b/src/mlx_dspark/cli.py
@@ -317,10 +317,12 @@ def cmd_serve(argv: list[str]) -> None:
                          "An over-long request is refused with the message Claude Code "
                          "recognises as a context limit, so it compacts and retries instead "
                          "of failing; lower it to keep the KV cache inside your RAM budget.")
-    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--host", default="127.0.0.1",
+                    help="address to bind (default: 127.0.0.1; use 0.0.0.0 to serve on LAN)")
     ap.add_argument("--port", type=int, default=8080)
     ap.add_argument("--api-key", default=None,
-                    help="if set, requests must send 'Authorization: Bearer <key>'")
+                    help="if set, every endpoint requires 'Authorization: Bearer <key>' "
+                         "or 'x-api-key: <key>'")
     ap.add_argument("--no-thinking", action="store_true",
                     help="default responses to non-thinking mode (Qwen3 enable_thinking=False); "
                          "clients can still override per-request")

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -1589,8 +1589,9 @@ def make_handler(engine: Engine, api_key: str | None):
 
         def _cors(self):
             self.send_header("Access-Control-Allow-Origin", "*")
-            self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type")
-            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header(
+                "Access-Control-Allow-Headers", "Authorization, x-api-key, Content-Type")
+            self.send_header("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS")
 
         def _send_json(self, status: int, obj: dict):
             body = json.dumps(obj).encode("utf-8")
@@ -1652,7 +1653,7 @@ def make_handler(engine: Engine, api_key: str | None):
 
         def do_HEAD(self):
             # Claude Code opens with a best-effort `HEAD /` connectivity probe.
-            self.send_response(200)
+            self.send_response(200 if self._authed() else 401)
             self.send_header("Content-Length", "0")
             self.send_header("Connection", "close")
             self._cors()
@@ -1673,6 +1674,8 @@ def make_handler(engine: Engine, api_key: str | None):
 
         def do_GET(self):
             route = self._route()
+            if not self._authed():
+                return self._send_error(401, "invalid api key", "authentication_error")
             if route == "/health":
                 # Answers even mid-swap so a client can poll the status through a model change.
                 # "loading" and "no_model" are distinct states: a client should wait through

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -86,8 +86,9 @@ def server():
     httpd.shutdown()
 
 
-def _get(base, path):
-    return json.loads(urllib.request.urlopen(base + path).read())
+def _get(base, path, headers=None):
+    req = urllib.request.Request(base + path, headers=headers or {})
+    return json.loads(urllib.request.urlopen(req).read())
 
 
 def _post(base, path, obj, stream=False, headers=None):
@@ -302,14 +303,39 @@ def test_auth_required():
     threading.Thread(target=httpd.serve_forever, daemon=True).start()
     base = f"http://127.0.0.1:{port}"
     try:
+        # Read-only discovery and telemetry are protected too.
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _get(base, "/health")
+        assert e.value.code == 401
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _get(base, "/health", {"Authorization": "Bearer wrong"})
+        assert e.value.code == 401
+
+        head = urllib.request.Request(base + "/", method="HEAD")
+        with pytest.raises(urllib.error.HTTPError) as e:
+            urllib.request.urlopen(head)
+        assert e.value.code == 401
+
         with pytest.raises(urllib.error.HTTPError) as e:
             _post(base, "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}]})
         assert e.value.code == 401
-        # with the right key it works
+        assert _get(base, "/health", {"x-api-key": "secret"})["status"] == "ok"
+
+        authed_head = urllib.request.Request(
+            base + "/", headers={"Authorization": "Bearer secret"}, method="HEAD")
+        assert urllib.request.urlopen(authed_head).status == 200
+
+        # Both supported credential headers work.
         c = _post(base, "/v1/chat/completions",
                   {"messages": [{"role": "user", "content": "hi"}]},
                   headers={"Authorization": "Bearer secret"})
         assert c["object"] == "chat.completion"
+
+        preflight = urllib.request.Request(base + "/v1/chat/completions", method="OPTIONS")
+        response = urllib.request.urlopen(preflight)
+        assert response.status == 204
+        allowed = response.headers["Access-Control-Allow-Headers"].lower()
+        assert "authorization" in allowed and "x-api-key" in allowed
     finally:
         httpd.shutdown()
 


### PR DESCRIPTION
hi!

firstly thanks for this project. MLX Dspark was the first project to get me better conistent Qwen 3.8 speeds with a nice simple UI. The only thing missing for me was the macOS app exposing the serve on lan option. 

This PR fixes that:

- Add independent macOS preferences for LAN serving and optional API-key authentication.
- Bind to 0.0.0.0 in LAN mode while keeping internal app traffic on loopback.
- Display active LAN endpoint URLs and warn when serving without authentication.
- Add API-key generation, editing, copying, validation, and plain-text preference persistence.
- Protect GET, HEAD, and POST routes when authentication is enabled.
- Document equivalent CLI usage and add macOS local-network permission metadata.

<img width="909" height="367" alt="image" src="https://github.com/user-attachments/assets/07f220cb-8698-42f5-9a42-4c3fcbabd29f" />
