### PR TITLE
Reasoning budget (LM Studio Bionic-style): opt-in thinking cap, live /admin/config, app controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,62 @@
 
 All notable changes to `mlx-dspark`. Versions follow [SemVer](https://semver.org/) (pre-1.0: minor-ish features land as patch bumps).
 
-## [0.14.0] — 2026-08-20 — depth-aware verify caps: long-context decode fixed
+## [Unreleased]
+
+### Fixed
+- **Non-streaming responses no longer leak a truncated thinking block as content on
+  prefill-opener templates** (Qwen3-2507/qwen3_5-class, whose chat template opens `<think>`
+  at the end of the prompt). When `max_tokens` cut the generation before the closer, the
+  text had neither opener nor closer and `split_thinking` misread it as all-answer — the
+  whole chain of thought landed in `content` (OpenAI) / a `text` block (Anthropic). The
+  non-streaming paths now pass the same prefilled-opener hint the streaming splitters have
+  always used (`split_thinking(..., in_thinking=...)` / `build_message(..., in_thinking=...)`),
+  so a truncated block correctly reads as all-reasoning. Surfaced by the reasoning-budget
+  end-to-end tests (a disabled budget is exactly the state that runs thinking into the cap).
+
+### Added
+- **`POST /admin/config`** sets the server-default reasoning knobs on the LIVE engine — no
+  model reload, effective on the very next request: `enable_thinking` (true/false, or null
+  to clear the override), `reasoning_budget` (0 disables), `reasoning_budget_message`
+  (null = the default text, `""` = close the block with no message). Values survive
+  `/admin/load` swaps and the no-model state (written into the holder's stored load
+  kwargs); the whole patch is validated before anything mutates, so a 400 never leaves a
+  partial update. `/health` now also reports `enable_thinking`, `reasoning_budget_message`,
+  and an `admin_config` capability flag (both the ready and no-model branches). Known
+  limitation (deliberately lock-free): a config landing inside an in-flight swap's
+  copy-to-publish window may be missed by that engine — the next swap still carries it.
+- **Mac app: Reasoning settings card** (Settings, all tiers) replicating LM Studio Bionic's
+  panel — an Enable Thinking switch, a Reasoning Budget checkbox + token field (unchecked by
+  default, like LM Studio; checking seeds 8192), and the budget message field. Changes apply
+  instantly via `/admin/config` (serialized latest-wins), persist across launches (re-pushed
+  on every server start, before the model loads), and the card is capability-gated on
+  `/health.admin_config` and disabled during model loads.
+- **Mac app: per-chat reasoning budget** in the chat settings popover — unchecked inherits
+  the server setting, a value enforces it for that conversation only (persisted in the
+  session file), and `0` lifts the budget for that chat even when the server default is on.
+  Hidden unless the loaded model honors budgets (`/health.supports_reasoning_budget`, false
+  on muse-format models) and inert while the chat's Allow-thinking veto is off.
+- **Reasoning budget** (LM Studio Bionic-style): a thinking model is stopped from reasoning
+  unboundedly. Past `N` tokens inside `<think>…</think>` (or Gemma-4's channel pair), the
+  budget message (default *"I have to answer now."*) plus the family-correct closing tag are
+  force-fed through the target — KV cache and drafter context stay consistent on every path
+  (dspark, dflash, lookup, baseline) — and generation continues into the answer. Fires at most
+  once per response, round-granular, disarmed when the model closes its own block, and counts
+  the injected tokens against `max_tokens`. **Opt-in at every layer** (like LM Studio's
+  unticked checkbox): the loops default to no budget, and the knobs are `serve` / `generate`
+  `--reasoning-budget N` (**default 0 = off**, e.g. 8192 to opt in) and
+  `--reasoning-budget-message`;
+  per-request `reasoning_budget` / `reasoning_budget_message` (OpenAI, `0` disables) and
+  `thinking.budget_tokens` (Anthropic — previously accepted-and-ignored, now enforced;
+  `type: "disabled"` also disables the budget); `/health` reports the default
+  (`reasoning_budget`, including in the `--no-model` state) and whether the loaded model
+  honors budgets at all (`supports_reasoning_budget`, false on muse-format models);
+  `GenResult.budget_forced` flags a fired budget. Not applied to muse/harmony-channel
+  models. Under `--max-batch`, an
+  **explicitly requested** budget takes the serial path (enforced exactly), while the ambient
+  server default never forfeits batching — concurrently batched rows just don't enforce it
+  (a lone request runs serial anyway and does). Library calls (`speculative_generate` etc.)
+  default to `think_budget=None` — unchanged behavior.
 
 ### Fixed
 - **OpenAI tool-calls streams no longer buffer the whole generation** (issue #19). With

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ mlx-dspark serve --model mlx-community/Qwen3-8B-8bit        # → http://127.0.0
 #   --mode auto|dspark|dflash|lookup|baseline   ·   --no-thinking   ·   --api-key KEY
 #   --reasoning-effort low|medium|xhigh   default reasoning depth on models that support it
 #                   (Qwen3.8-class; /health reports support, requests can override)
+#   --reasoning-budget N   cap thinking at N tokens (LM Studio Bionic-style; default 0 =
+#                   off, opt in with e.g. 8192): past the budget the message + closing tag
+#                   are force-injected so the model answers instead of overthinking.
+#                   --reasoning-budget-message sets the injected text
+#                   (default "I have to answer now.")
 #   --no-model      start instantly with nothing loaded; POST /admin/load loads later,
 #                   POST /admin/unload frees the model again (port survives both).
 #                   A first-time load reports download progress in /health and is
@@ -233,8 +238,14 @@ The server speaks the OpenAI API: `POST /v1/chat/completions` (streaming **and**
 multi-turn), `POST /v1/completions`, `GET /v1/models`, `GET /health`, `GET /metrics`. It supports
 `temperature`, `top_p`, `top_k`, `max_tokens`, `stop`, `seed`, `presence_penalty` / `frequency_penalty`,
 `logprobs` / `top_logprobs`, **tool calling** (`tools` / `tool_calls`), a per-request thinking toggle
-(`enable_thinking`), and per-request `reasoning_effort` on models whose template supports it (Qwen3.8-class;
-`GET /health` reports `supports_reasoning_effort`). Each response carries an `x_mlx_dspark` block (accept length + tok/s) so the
+(`enable_thinking`), per-request `reasoning_effort` on models whose template supports it (Qwen3.8-class;
+`GET /health` reports `supports_reasoning_effort`), and a per-request **reasoning budget**
+(`reasoning_budget`, plus optional `reasoning_budget_message`) that caps how long a thinking model may
+reason before being forced to answer — `0` disables it for the request, and `GET /health` reports the
+server defaults (`reasoning_budget`, `reasoning_budget_message`, `enable_thinking`). Those server
+defaults are also settable **live** — `POST /admin/config` changes them on the running engine with no
+model reload (`/health` advertises the capability as `admin_config`); values stick across
+`/admin/load` swaps and the no-model state. Each response carries an `x_mlx_dspark` block (accept length + tok/s) so the
 spec-decode gain is visible. **Continuous batching** (`--max-batch N`) serves concurrent requests in one
 batched forward for ~2.5× aggregate throughput (see [Concurrent throughput](#concurrent-throughput));
 **prefix caching** (on by default) reuses the conversation prefix so multi-turn chat and agents don't
@@ -268,7 +279,10 @@ Tool calling, multi-turn `tool_use`/`tool_result` history, `stop_sequences`, and
 translated to whatever the loaded model's own chat template expects — including each family's tool
 syntax (Hermes JSON, Gemma-4, and the XML `<function=>` form) — and a reasoning model's `<think>` or
 `<|channel>thought` output is lifted into proper Anthropic `thinking` blocks rather than leaking as
-prose.
+prose. `thinking: {"type": "enabled", "budget_tokens": N}` is **enforced**: past N thinking tokens the
+budget message + closing tag are force-injected so the model answers (the server's `--reasoning-budget`
+default applies when the request doesn't send one; `type: "disabled"` turns both thinking and the
+budget off).
 
 **Measured** — each of these ran a real Claude Code session that read a buggy file and fixed it with
 the `Edit` tool (M4 Pro, `--no-thinking`, identical task):
@@ -320,6 +334,7 @@ Practical notes for a local model:
 | **Use a tool-calling model** | These are tool-use agents first. Qwen3-8B and up handle it; smaller models flail. |
 | **Agent choice moves the clock more than model choice** | The client's prompt size is the dominant cost on a local model — a lean agent like pi is an order of magnitude faster on the same hardware and the same task. |
 | **`--no-thinking` is a speed knob, not a requirement** | Leaving it off works fine — reasoning is streamed as proper `thinking` blocks either way. It just costs: on Qwen3-8B the same Claude Code task ran 3:17 and 2762 output tokens with thinking vs ~2:20 and 169 without, since the model thinks before *every* tool call. A client sending `thinking: {"type": "disabled"}` gets the same effect per-request. Note it's a no-op on Gemma-4, whose template doesn't think by default. |
+| **The reasoning budget is the middle ground** (v0.14) | `--reasoning-budget N` (opt-in — the default is off; 8192 is the LM Studio-parity value) keeps thinking but stops a model from sitting in `<think>` for minutes on a simple question: past N thinking tokens the budget message (default *"I have to answer now."*, `--reasoning-budget-message`) plus the closing tag are force-fed through the model, which then answers normally. Enforcement is approximate (round-granular on the speculative paths, can overshoot by a few tokens), fires at most once per response, counts the injected tokens against `max_tokens`, and doesn't apply to gpt-oss/harmony-channel models. Under `--max-batch`, a budget the request asked for **explicitly** runs serially so it's enforced exactly; the server default never costs you batching — concurrently batched rows simply don't enforce it (a lone request runs serial anyway and does). |
 | **Leave prefix caching on** | It is doing most of the work (see the table). The first request of a *cold server* is the slow one; since 0.10.1 a fresh session over a system prompt the server has already seen partially reuses it (rungs — see [Prefix caching](#prefix-caching)). |
 | **Context** | An over-long request is refused with the wording Claude Code recognises as a context limit, so it compacts and retries instead of dying. `--context-window N` lowers the bar deliberately (e.g. to keep the KV cache inside your RAM budget). |
 | **Streams stay alive, and disconnects actually stop generation** (v0.12.3) | Keep-alive frames flow every 15 s through stretches with nothing on the wire (long prefills; tool-call responses are buffered until complete), so agent clients don't idle-timeout mid-request. And if a client *does* vanish, generation stops at the next round instead of running to `max_tokens` while later requests queue behind it — the "server stalls but `/health` is fine" failure mode. |

--- a/apps/MacApp/README.md
+++ b/apps/MacApp/README.md
@@ -8,7 +8,10 @@ terminal user would run.
 > syntax highlighting, collapsible reasoning), Lab (Race with lossless verdict, live
 > acceptance decay, this Mac's cost curves), Models (measured pairs with speedups, anything
 > on disk, any HF repo, hot swap via `/admin/load`), Agents (per-client config + round-trip
-> test), menu bar with live rate/memory/accept ribbon, DMG + Homebrew cask tooling.
+> test), Settings → Reasoning (LM Studio Bionic-style thinking switch + reasoning budget —
+> off by default, opt-in — applied live via `/admin/config`, no reload; the chat settings
+> popover adds a per-conversation budget override), menu bar with live rate/memory/accept
+> ribbon, DMG + Homebrew cask tooling.
 >
 > **Engine version:** the bootstrapper installs the **latest PyPI release** at launch (no
 > pin; it rebuilds the runtime when a newer release exists, and offline launches keep the

--- a/apps/MacApp/Sources/AppCore/APIClient.swift
+++ b/apps/MacApp/Sources/AppCore/APIClient.swift
@@ -49,6 +49,22 @@ public struct HealthInfo: Decodable, Sendable, Equatable {
     /// `/admin/load` override, so the picker hides then (a control that silently does
     /// nothing is worse than none).
     public let kvBits: Int?
+    /// Server-default reasoning budget: thinking tokens before the engine force-closes the
+    /// block (nil = disabled OR an older engine that doesn't report it — gate on
+    /// `adminConfig`, not this).
+    public let reasoningBudget: Int?
+    /// Text the engine injects when the budget fires. Nil = the engine's built-in default.
+    public let reasoningBudgetMessage: String?
+    /// Server-default thinking switch: true/false = an explicit override, nil = the chat
+    /// template's own default (or an older engine).
+    public let enableThinking: Bool?
+    /// Capability flag: the engine accepts `POST /admin/config` (live reasoning settings,
+    /// no reload). The Reasoning settings card gates on this — older engines 404 there.
+    public let adminConfig: Bool?
+    /// Whether the LOADED model honors reasoning budgets at all — muse-format models
+    /// don't. Per-request budget controls gate on this, not `adminConfig` (which is about
+    /// the server). Nil with no model loaded and on older engines.
+    public let supportsReasoningBudget: Bool?
 
     enum CodingKeys: String, CodingKey {
         case status, model, mode, target, drafter, download
@@ -60,6 +76,11 @@ public struct HealthInfo: Decodable, Sendable, Equatable {
         case raceArmConfidence = "race_arm_confidence"
         case lookupDrafts = "lookup_drafts"
         case kvBits = "kv_bits"
+        case reasoningBudget = "reasoning_budget"
+        case reasoningBudgetMessage = "reasoning_budget_message"
+        case enableThinking = "enable_thinking"
+        case adminConfig = "admin_config"
+        case supportsReasoningBudget = "supports_reasoning_budget"
     }
 
     /// True when a model is loaded and serving (`status == "ok"`).
@@ -115,6 +136,19 @@ public struct LoadStatus: Decodable, Sendable {
     public let loading: Bool
     public let model: String?
     public let error: String?
+}
+
+/// The effective reasoning defaults, as `/admin/config` echoes them back.
+public struct ReasoningConfig: Decodable, Sendable, Equatable {
+    public let enableThinking: Bool?
+    public let reasoningBudget: Int?
+    public let reasoningBudgetMessage: String?
+
+    enum CodingKeys: String, CodingKey {
+        case enableThinking = "enable_thinking"
+        case reasoningBudget = "reasoning_budget"
+        case reasoningBudgetMessage = "reasoning_budget_message"
+    }
 }
 
 /// One event from a streaming completion.
@@ -239,6 +273,34 @@ public struct APIClient: Sendable {
         return try JSONDecoder().decode(LoadStatus.self, from: data)
     }
 
+    /// The `/admin/config` payload as a pure function, so the encoding is unit-testable.
+    /// `thinkingEnabled` is sent as an explicit true/false BOTH ways (LM Studio semantics:
+    /// ON must win over a template whose own default is off — `null`, which merely clears
+    /// the override, stays an API-only affair). `budget` 0 = disabled (the checkbox-off
+    /// state). `message` nil = the engine's default text as JSON null; `""` is sent as `""`
+    /// — the engine's explicit close-with-no-message mode.
+    public static func reasoningPayload(thinkingEnabled: Bool, budget: Int,
+                                        message: String?) -> [String: Any] {
+        ["enable_thinking": thinkingEnabled,
+         "reasoning_budget": budget,
+         "reasoning_budget_message": message ?? NSNull()]
+    }
+
+    /// Set the server-default reasoning knobs live (`POST /admin/config`) — no model
+    /// reload; also effective in the no-model state (the next load carries the values).
+    /// Gate calls on `/health.admin_config` — older engines 404 here.
+    @discardableResult
+    public func configureReasoning(thinkingEnabled: Bool, budget: Int,
+                                   message: String?) async throws -> ReasoningConfig {
+        let payload = Self.reasoningPayload(thinkingEnabled: thinkingEnabled,
+                                            budget: budget, message: message)
+        let body = try JSONSerialization.data(withJSONObject: payload)
+        let req = request("admin/config", method: "POST", body: body)
+        let (data, response) = try await session.data(for: req)
+        try Self.check(response, data)
+        return try JSONDecoder().decode(ReasoningConfig.self, from: data)
+    }
+
     /// Cancel an in-flight first-time download (`/admin/load/cancel`). The blocked
     /// `/admin/load` then fails cleanly and the server stays up, model-less. `cleanup`
     /// also removes the partial files; the default keeps them so loading the same model
@@ -345,18 +407,21 @@ public struct APIClient: Sendable {
         }
     }
 
-    /// Stream a chat completion, yielding text deltas and finally the spec-decode stats.
-    public func streamChat(
+    /// The chat-completions request body, as a pure function so the encoding is
+    /// unit-testable — nil-omit vs real-value matters (a per-chat `reasoning_budget` of 0
+    /// must survive as a JSON 0, the engine's "unbounded for this request").
+    public static func chatPayload(
         model: String,
         messages: [[String: String]],
         temperature: Double? = nil,
         maxTokens: Int? = nil,
         enableThinking: Bool? = nil,
         reasoningEffort: String? = nil,
+        reasoningBudget: Int? = nil,
         topP: Double? = nil,
         seed: Int? = nil,
         stop: [String]? = nil
-    ) -> AsyncThrowingStream<ChatEvent, Error> {
+    ) -> [String: Any] {
         var payload: [String: Any] = [
             "model": model,
             "messages": messages,
@@ -366,9 +431,31 @@ public struct APIClient: Sendable {
         if let maxTokens { payload["max_tokens"] = maxTokens }
         if let enableThinking { payload["enable_thinking"] = enableThinking }
         if let reasoningEffort { payload["reasoning_effort"] = reasoningEffort }
+        if let reasoningBudget { payload["reasoning_budget"] = reasoningBudget }
         if let topP { payload["top_p"] = topP }
         if let seed { payload["seed"] = seed }
         if let stop, !stop.isEmpty { payload["stop"] = stop }
+        return payload
+    }
+
+    /// Stream a chat completion, yielding text deltas and finally the spec-decode stats.
+    public func streamChat(
+        model: String,
+        messages: [[String: String]],
+        temperature: Double? = nil,
+        maxTokens: Int? = nil,
+        enableThinking: Bool? = nil,
+        reasoningEffort: String? = nil,
+        reasoningBudget: Int? = nil,
+        topP: Double? = nil,
+        seed: Int? = nil,
+        stop: [String]? = nil
+    ) -> AsyncThrowingStream<ChatEvent, Error> {
+        let payload = Self.chatPayload(
+            model: model, messages: messages, temperature: temperature,
+            maxTokens: maxTokens, enableThinking: enableThinking,
+            reasoningEffort: reasoningEffort, reasoningBudget: reasoningBudget,
+            topP: topP, seed: seed, stop: stop)
 
         return AsyncThrowingStream { continuation in
             let task = Task {

--- a/apps/MacApp/Sources/AppCore/ChatStore.swift
+++ b/apps/MacApp/Sources/AppCore/ChatStore.swift
@@ -30,15 +30,19 @@ public struct ChatSession: Identifiable, Codable, Sendable {
     public var createdAt: Date
     public var updatedAt: Date
     public var messages: [ChatMessage]
+    /// Per-conversation reasoning-budget override; nil = inherit the server setting.
+    /// Optional so session files saved by older builds still decode.
+    public var reasoningBudget: Int?
 
     public init(id: UUID = UUID(), title: String = "New chat",
                 createdAt: Date = Date(), updatedAt: Date = Date(),
-                messages: [ChatMessage] = []) {
+                messages: [ChatMessage] = [], reasoningBudget: Int? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.messages = messages
+        self.reasoningBudget = reasoningBudget
     }
 
     /// Titles derive from the first thing the user asked; nobody names chats by hand.

--- a/apps/MacApp/Sources/AppCore/Coalescer.swift
+++ b/apps/MacApp/Sources/AppCore/Coalescer.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Serialized, coalescing runner for an idempotent async operation — the "instant apply"
+/// primitive. Independent per-change `Task`s can complete out of order across network
+/// awaits, leaving a server on a stale value; `Coalescer` guarantees latest-wins instead:
+/// one run at a time, and a `schedule()` arriving mid-run queues exactly one re-run, so the
+/// final run always observes the newest state (the operation reads its inputs at send time).
+///
+/// The operation is FIXED at init and the trigger takes no argument — deliberately. A
+/// schedule-accepts-a-closure API would re-run an *older* closure after coalescing, which is
+/// precisely the staleness this type exists to prevent.
+///
+/// `@MainActor`: it owns mutable task/pending state and its operation typically captures a
+/// main-actor model object, so the isolation is part of the contract.
+@MainActor
+public final class Coalescer {
+    private let op: @MainActor @Sendable () async -> Void
+    private var running: Task<Void, Never>?
+    private var pending = false
+
+    public init(op: @escaping @MainActor @Sendable () async -> Void) {
+        self.op = op
+    }
+
+    /// Run the operation, serialized: if a run is in flight, remember to run once more when
+    /// it finishes (multiple calls coalesce into that single re-run).
+    public func schedule() {
+        if running != nil {
+            pending = true
+            return
+        }
+        running = Task { [weak self] in
+            guard let self else { return }
+            repeat {
+                self.pending = false
+                await self.op()
+            } while self.pending
+            self.running = nil
+        }
+    }
+}

--- a/apps/MacApp/Sources/AppHost/AppModel.swift
+++ b/apps/MacApp/Sources/AppHost/AppModel.swift
@@ -124,9 +124,34 @@ final class AppModel: ObservableObject {
         didSet { Defaults.chatSettings = chatSettings }
     }
 
+    // MARK: Reasoning (Settings → Reasoning)
+    // Server defaults for every request that doesn't set its own values, applied live via
+    // POST /admin/config (no model reload) and re-pushed on every server start, so they
+    // survive restarts. The app's persisted values are the source of truth.
+    @Published var thinkingEnabled: Bool = Defaults.thinkingEnabled {
+        didSet { Defaults.thinkingEnabled = thinkingEnabled }
+    }
+    @Published var reasoningBudgetEnabled: Bool = Defaults.reasoningBudgetEnabled {
+        didSet { Defaults.reasoningBudgetEnabled = reasoningBudgetEnabled }
+    }
+    @Published var reasoningBudget: Int = Defaults.reasoningBudget {
+        didSet { Defaults.reasoningBudget = reasoningBudget }
+    }
+    /// nil = the engine's default message; "" = explicit close-with-no-message.
+    @Published var reasoningBudgetMessage: String? = Defaults.reasoningBudgetMessage {
+        didSet { Defaults.reasoningBudgetMessage = reasoningBudgetMessage }
+    }
+    /// A failed /admin/config push. Rendered inline in the Reasoning card.
+    @Published var reasoningApplyError: String?
+
     // MARK: Chat sessions
     @Published var sessions: [ChatSession] = []
     @Published private(set) var currentSessionID: UUID?
+    /// The CURRENT conversation's reasoning-budget override (nil = inherit the server
+    /// setting). Deliberately not in ChatSettings and not a Defaults key: it is
+    /// per-conversation state that lives in the session files — persisted in
+    /// persistCurrentSession(), restored on select/load, reset for a new chat.
+    @Published var chatReasoningBudget: Int?
 
     // MARK: Telemetry (Lab)
     @Published var rounds: [RoundEvent] = []
@@ -403,7 +428,56 @@ final class AppModel: ObservableObject {
         let client = APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
         self.apiClient = client
         currentHealth = try? await client.health()
+        // Push the persisted reasoning defaults NOW — after the client exists, before any
+        // model load — so the engine's stored load kwargs already carry them when weights
+        // come up. Unconditional on capable engines: argv can't express an explicit
+        // thinking-ON, so this push is what makes the setting survive restarts.
+        if currentHealth?.adminConfig == true {
+            await performApplyReasoning()
+        }
         return true
+    }
+
+    // MARK: Reasoning apply (instant, serialized latest-wins)
+
+    private lazy var reasoningCoalescer = Coalescer { [weak self] in
+        await self?.performApplyReasoning()
+    }
+
+    /// Instant apply for the Reasoning settings card. Serialized and coalescing: rapid
+    /// toggles/edits can't complete out of order, and the final request always carries the
+    /// newest values (read at send time).
+    func scheduleApplyReasoning() {
+        reasoningCoalescer.schedule()
+    }
+
+    /// A model load snapshots the engine's stored kwargs before publishing the new engine,
+    /// so a reasoning config that lands mid-load (the accepted lock-free window — e.g. a
+    /// coalesced apply still in flight when the load starts) can miss the swapped-in engine.
+    /// Re-pushing the full configuration after every successful load closes the
+    /// app-originated race without locks; the push is idempotent and instant.
+    private func reapplyReasoningAfterLoad() async {
+        guard currentHealth?.adminConfig == true else { return }
+        await performApplyReasoning()
+    }
+
+    private func performApplyReasoning() async {
+        guard let client = apiClient else { return }   // server not up; connect() will push
+        reasoningApplyError = nil
+        let budget = reasoningBudgetEnabled ? reasoningBudget : 0
+        logStore.note("reasoning config → thinking \(thinkingEnabled ? "on" : "off") · "
+                      + "budget \(budget > 0 ? String(budget) : "off")")
+        do {
+            _ = try await client.configureReasoning(thinkingEnabled: thinkingEnabled,
+                                                    budget: budget,
+                                                    message: reasoningBudgetMessage)
+            currentHealth = try? await client.health()
+        } catch {
+            // The card only shows on engines advertising admin_config, so a failure here
+            // is a genuine configuration problem — surface it, don't swallow it.
+            reasoningApplyError = error.localizedDescription
+            logStore.note("reasoning config failed — \(error.localizedDescription)")
+        }
     }
 
     /// Load `target` into the running server (`/admin/load`) with inline progress — the
@@ -443,6 +517,7 @@ final class AppModel: ObservableObject {
             // Re-point health at the new model and restart the telemetry stream (the old one
             // ended when the engine it was streaming from was torn down).
             currentHealth = try? await client.health()
+            await reapplyReasoningAfterLoad()
             startTelemetry()
             startMemoryPolling()
             await refreshDiagnostics()
@@ -559,6 +634,7 @@ final class AppModel: ObservableObject {
                                            lookupDrafts: lookupDrafts,
                                            kvBits: kvBits)
             currentHealth = try? await client.health()
+            await reapplyReasoningAfterLoad()
             startTelemetry()
             startMemoryPolling()
             await refreshDiagnostics()
@@ -568,6 +644,7 @@ final class AppModel: ObservableObject {
             // If even that fails, the server survives model-less; the picker still works.
             _ = try? await client.loadModel(model)
             currentHealth = try? await client.health()
+            await reapplyReasoningAfterLoad()
             startTelemetry()
             startMemoryPolling()
         }
@@ -756,6 +833,9 @@ final class AppModel: ObservableObject {
                     // The template ignores effort when thinking is off, so don't send it then.
                     reasoningEffort: self.chatSettings.thinking && self.supportsReasoningEffort
                         ? self.chatSettings.reasoningEffort : nil,
+                    // A budget is meaningless when thinking is vetoed for this chat.
+                    reasoningBudget: self.chatSettings.thinking
+                        ? self.chatReasoningBudget : nil,
                     topP: self.chatSettings.topP,
                     seed: self.chatSettings.seed,
                     stop: self.chatSettings.stopList
@@ -819,9 +899,11 @@ final class AppModel: ObservableObject {
            let session = sessions.first(where: { $0.id == saved }) {
             currentSessionID = session.id
             messages = session.messages
+            chatReasoningBudget = session.reasoningBudget
         } else if let latest = sessions.first {
             currentSessionID = latest.id
             messages = latest.messages
+            chatReasoningBudget = latest.reasoningBudget
         }
         // No sessions yet: stay unsaved until the first message, so quitting a fresh app
         // doesn't litter empty files.
@@ -833,6 +915,7 @@ final class AppModel: ObservableObject {
         currentSessionID = nil
         Defaults.currentSession = nil
         messages = []
+        chatReasoningBudget = nil
         chatError = nil
         screen = .chat
     }
@@ -845,6 +928,7 @@ final class AppModel: ObservableObject {
         currentSessionID = session.id
         Defaults.currentSession = session.id
         messages = session.messages
+        chatReasoningBudget = session.reasoningBudget
         chatError = nil
     }
 
@@ -855,6 +939,7 @@ final class AppModel: ObservableObject {
             currentSessionID = nil
             Defaults.currentSession = nil
             messages = []
+            chatReasoningBudget = nil
         }
     }
 
@@ -870,6 +955,7 @@ final class AppModel: ObservableObject {
             Defaults.currentSession = session.id
         }
         session.messages = messages
+        session.reasoningBudget = chatReasoningBudget
         session.updatedAt = Date()
         session.retitleFromContent()
         chatStore.save(session)
@@ -1070,5 +1156,34 @@ enum Defaults {
             return settings
         }
         set { store.set(try? JSONEncoder().encode(newValue), forKey: "chatSettings") }
+    }
+
+    // Reasoning defaults (Settings → Reasoning). Never-set means: thinking on, budget OFF
+    // (opt-in, like LM Studio's unticked checkbox; 8192 seeds the field when enabled),
+    // the engine's own budget message.
+    static var thinkingEnabled: Bool {
+        get { store.object(forKey: "thinkingEnabled") == nil
+              ? true : store.bool(forKey: "thinkingEnabled") }
+        set { store.set(newValue, forKey: "thinkingEnabled") }
+    }
+
+    static var reasoningBudgetEnabled: Bool {
+        get { store.bool(forKey: "reasoningBudgetEnabled") }
+        set { store.set(newValue, forKey: "reasoningBudgetEnabled") }
+    }
+
+    static var reasoningBudget: Int {
+        get {
+            let v = store.integer(forKey: "reasoningBudget")
+            return v > 0 ? v : 8192
+        }
+        set { store.set(newValue, forKey: "reasoningBudget") }
+    }
+
+    /// nil (key never set) = the engine's default text; a stored value — INCLUDING "" —
+    /// is explicit ("" is the engine's close-with-no-message mode, a real choice).
+    static var reasoningBudgetMessage: String? {
+        get { store.string(forKey: "reasoningBudgetMessage") }
+        set { store.set(newValue, forKey: "reasoningBudgetMessage") }
     }
 }

--- a/apps/MacApp/Sources/AppHost/ChatScreen.swift
+++ b/apps/MacApp/Sources/AppHost/ChatScreen.swift
@@ -130,6 +130,7 @@ struct ChatSettingsPanel: View {
     @EnvironmentObject private var model: AppModel
     @State private var maxTokensText: String = ""
     @State private var seedText: String = ""
+    @State private var chatBudgetText: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -252,6 +253,49 @@ struct ChatSettingsPanel: View {
                 }
             }
 
+            // Only for models that honor per-request budgets (muse-format models don't —
+            // the server reports support in /health). Per-CHAT and three-state, unlike the
+            // Settings card: unchecked = inherit the server setting, a value = enforce it
+            // for this conversation, 0 = unbounded here even if the server default is on.
+            if model.health?.supportsReasoningBudget == true {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Toggle(isOn: Binding(
+                            get: { model.chatReasoningBudget != nil },
+                            set: { on in
+                                // Keep the text mirror in lockstep so uncheck→recheck
+                                // can't show one number while sending another.
+                                model.chatReasoningBudget = on ? 8192 : nil
+                                chatBudgetText = on ? "8192" : ""
+                            }
+                        )) {
+                            Text("Reasoning budget")
+                        }
+                        Spacer()
+                        if model.chatReasoningBudget != nil {
+                            TextField("8192", text: $chatBudgetText)
+                                .textFieldStyle(.roundedBorder)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: 92)
+                                .accessibilityLabel("Per-chat reasoning budget tokens")
+                                .onChange(of: chatBudgetText) { _, text in
+                                    // Only a parsed non-negative number commits; a stray
+                                    // keystroke must not nil the value (that would uncheck
+                                    // the box and collapse this row mid-typing).
+                                    if let v = Int(text), v >= 0 {
+                                        model.chatReasoningBudget = v
+                                    }
+                                }
+                        }
+                    }
+                    .disabled(!model.chatSettings.thinking)
+                    Text("Overrides the server's budget for this chat only. 0 lifts the "
+                         + "budget entirely; uncheck to inherit the server setting.")
+                        .font(.caption2).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
             // Only for models whose template actually reads it (the server reports support
             // in /health) — a control that silently does nothing is worse than none.
             if model.supportsReasoningEffort {
@@ -279,6 +323,7 @@ struct ChatSettingsPanel: View {
         .onAppear {
             maxTokensText = model.chatSettings.maxTokens.map(String.init) ?? ""
             seedText = model.chatSettings.seed.map(String.init) ?? ""
+            chatBudgetText = model.chatReasoningBudget.map(String.init) ?? ""
         }
     }
 }

--- a/apps/MacApp/Sources/AppHost/SettingsScreen.swift
+++ b/apps/MacApp/Sources/AppHost/SettingsScreen.swift
@@ -9,6 +9,10 @@ struct SettingsScreen: View {
             VStack(alignment: .leading, spacing: 16) {
                 DetailLevelCard()
                 if model.detail != .simple { DecodingCard() }
+                // User-level like LM Studio's panel, so it shows in every tier — but only
+                // on engines that accept POST /admin/config (a control that silently does
+                // nothing is worse than none).
+                if model.health?.adminConfig == true { ReasoningCard() }
                 if let report = model.doctorReport { MachineCard(report: report) }
                 ServerCard()
                 AboutCard()
@@ -409,6 +413,123 @@ struct MachineCard: View {
             Text(value).font(.callout).textSelection(.enabled)
             Spacer()
         }
+    }
+}
+
+/// LM Studio Bionic-style Reasoning panel — the SERVER defaults for thinking models,
+/// applied instantly via `POST /admin/config` (no model reload) and persisted so every
+/// server start re-pushes them. No Apply button: toggles apply on change, fields on
+/// Enter/focus loss; `AppModel`'s coalescer serializes the pushes latest-wins.
+struct ReasoningCard: View {
+    @EnvironmentObject private var model: AppModel
+    @State private var budgetText = ""
+    @State private var messageText = ""
+    @FocusState private var focus: Field?
+
+    private enum Field { case budget, message }
+
+    /// The engine's built-in budget message, shown as the field's initial editable value.
+    private static let defaultMessage = "I have to answer now."
+
+    var body: some View {
+        Card(title: "Reasoning",
+             subtitle: "Server defaults for thinking models — applied instantly, no reload.") {
+            VStack(alignment: .leading, spacing: 10) {
+                thinkingRow
+                Divider()
+                budgetRow
+                messageRow
+                if let err = model.reasoningApplyError {
+                    Text(err).font(.caption).foregroundStyle(.orange)
+                }
+                Text("Requests that set their own values still win (e.g. a client sending "
+                     + "Anthropic budget_tokens), and concurrently batched requests skip "
+                     + "the server default. The chat toolbar's Allow-thinking toggle can "
+                     + "still veto thinking per chat.")
+                    .font(.caption).foregroundStyle(.secondary)
+            }
+        }
+        // The config endpoint is deliberately lock-free server-side; not posting while our
+        // own /admin/load runs is what keeps the app clear of the accepted config/load race.
+        .disabled(model.isModelLoading)
+        .opacity(model.isModelLoading ? 0.55 : 1)
+        .onAppear {
+            budgetText = String(model.reasoningBudget)
+            messageText = model.reasoningBudgetMessage ?? Self.defaultMessage
+        }
+        .onChange(of: focus) { old, _ in
+            // Commit whichever field just lost focus — tabbing straight from one field to
+            // the other must still commit the first (onSubmit alone misses click-away).
+            if old == .budget { commitBudget() }
+            if old == .message { commitMessage() }
+        }
+    }
+
+    @ViewBuilder private var thinkingRow: some View {
+        Toggle(isOn: $model.thinkingEnabled) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Enable Thinking")
+                Text("Controls thinking for chat templates that support enable_thinking.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+        }
+        .toggleStyle(.switch)
+        .onChange(of: model.thinkingEnabled) { _, _ in model.scheduleApplyReasoning() }
+    }
+
+    @ViewBuilder private var budgetRow: some View {
+        HStack(spacing: 8) {
+            Toggle("Reasoning Budget", isOn: $model.reasoningBudgetEnabled)
+                .onChange(of: model.reasoningBudgetEnabled) { _, _ in
+                    model.scheduleApplyReasoning()
+                }
+                .help("Caps how many tokens a thinking model may spend inside its reasoning "
+                      + "block. Past the budget, the message below plus the closing tag are "
+                      + "force-fed through the model so it answers instead of overthinking.")
+            Spacer()
+            TextField("8192", text: $budgetText)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 92)
+                .multilineTextAlignment(.trailing)
+                .focused($focus, equals: .budget)
+                .onSubmit { commitBudget() }
+                .disabled(!model.reasoningBudgetEnabled)
+                .accessibilityLabel("Reasoning budget tokens")
+        }
+    }
+
+    @ViewBuilder private var messageRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Reasoning Budget Message").font(.callout).foregroundStyle(.secondary)
+            TextField("", text: $messageText)
+                .textFieldStyle(.roundedBorder)
+                .focused($focus, equals: .message)
+                .onSubmit { commitMessage() }
+                .accessibilityLabel("Reasoning budget message")
+            Text("Injected when the budget fires. Clear it to close the thinking block "
+                 + "with no message.")
+                .font(.caption2).foregroundStyle(.secondary)
+        }
+    }
+
+    /// A checked budget must always mean an enforced budget: only a positive integer
+    /// commits; 0, negative, or non-numeric input restores the last valid value (the
+    /// checkbox — not a zero — is how you disable).
+    private func commitBudget() {
+        let trimmed = budgetText.trimmingCharacters(in: .whitespaces)
+        if let value = Int(trimmed), value >= 1, value != model.reasoningBudget {
+            model.reasoningBudget = value
+            model.scheduleApplyReasoning()
+        }
+        budgetText = String(model.reasoningBudget)      // echo back the effective value
+    }
+
+    private func commitMessage() {
+        guard messageText != (model.reasoningBudgetMessage ?? Self.defaultMessage) else {
+            return
+        }
+        model.reasoningBudgetMessage = messageText      // "" = explicit close-with-no-message
+        model.scheduleApplyReasoning()
     }
 }
 

--- a/apps/MacApp/Tests/AppCoreTests/AppCoreTests.swift
+++ b/apps/MacApp/Tests/AppCoreTests/AppCoreTests.swift
@@ -143,6 +143,204 @@ struct HealthInfoTests {
         let health = try JSONDecoder().decode(HealthInfo.self, from: Data(json.utf8))
         #expect(health.drafter == nil)
         #expect(health.contextWindow == nil)
+        // reasoning keys are optional: older engines don't report them
+        #expect(health.reasoningBudget == nil)
+        #expect(health.enableThinking == nil)
+        #expect(health.adminConfig == nil)
+    }
+
+    /// The reasoning keys a current engine reports — the Settings card's data source and
+    /// its `admin_config` capability gate.
+    @Test func decodesReasoningKeys() throws {
+        let json = """
+        {"status": "ok", "model": "X", "mode": "dflash",
+         "reasoning_budget": 8192, "reasoning_budget_message": "Wrap it up.",
+         "enable_thinking": false, "admin_config": true,
+         "supports_reasoning_budget": true}
+        """
+        let health = try JSONDecoder().decode(HealthInfo.self, from: Data(json.utf8))
+        #expect(health.reasoningBudget == 8192)
+        #expect(health.reasoningBudgetMessage == "Wrap it up.")
+        #expect(health.enableThinking == false)
+        #expect(health.adminConfig == true)
+        #expect(health.supportsReasoningBudget == true)
+        // absent on older engines and in the no-model state — the per-chat control hides
+        #expect((try JSONDecoder().decode(
+            HealthInfo.self,
+            from: Data(#"{"status":"no_model"}"#.utf8))).supportsReasoningBudget == nil)
+    }
+}
+
+@Suite("Reasoning payload")
+struct ReasoningPayloadTests {
+    /// Thinking is explicit true/false BOTH ways — ON must win over a template whose own
+    /// default is off, so it can never be encoded as null (null merely clears the override).
+    @Test func thinkingIsExplicitBothWays() {
+        let on = APIClient.reasoningPayload(thinkingEnabled: true, budget: 8192, message: nil)
+        #expect(on["enable_thinking"] as? Bool == true)
+        let off = APIClient.reasoningPayload(thinkingEnabled: false, budget: 8192, message: nil)
+        #expect(off["enable_thinking"] as? Bool == false)
+    }
+
+    /// Budget 0 is the checkbox-off state and must pass through as a real 0 (the engine's
+    /// "disabled"), not be dropped or nulled.
+    @Test func zeroBudgetPassesThrough() {
+        let p = APIClient.reasoningPayload(thinkingEnabled: true, budget: 0, message: nil)
+        #expect(p["reasoning_budget"] as? Int == 0)
+    }
+
+    /// nil message = engine default (JSON null); "" = the engine's explicit
+    /// close-with-no-message mode — the two must stay distinguishable on the wire.
+    @Test func messageNilVersusEmptyVersusText() {
+        let none = APIClient.reasoningPayload(thinkingEnabled: true, budget: 1, message: nil)
+        #expect(none["reasoning_budget_message"] is NSNull)
+        let empty = APIClient.reasoningPayload(thinkingEnabled: true, budget: 1, message: "")
+        #expect(empty["reasoning_budget_message"] as? String == "")
+        let text = APIClient.reasoningPayload(thinkingEnabled: true, budget: 1,
+                                              message: "I have to answer now.")
+        #expect(text["reasoning_budget_message"] as? String == "I have to answer now.")
+    }
+}
+
+@Suite("Chat payload")
+struct ChatPayloadTests {
+    private let msgs = [["role": "user", "content": "hi"]]
+
+    /// The three keys every request carries, and nothing else when the options are nil.
+    @Test func minimalPayloadOmitsEveryOptional() {
+        let p = APIClient.chatPayload(model: "m", messages: msgs)
+        #expect(p["model"] as? String == "m")
+        #expect(p["stream"] as? Bool == true)
+        #expect((p["messages"] as? [[String: String]]) == msgs)
+        for key in ["temperature", "max_tokens", "enable_thinking", "reasoning_effort",
+                    "reasoning_budget", "top_p", "seed", "stop"] {
+            #expect(p[key] == nil, "\(key) must be omitted when nil")
+        }
+    }
+
+    /// Per-chat budget: nil = inherit (omitted); 0 = "unbounded this chat" and must
+    /// survive as a real JSON 0, not be dropped; a value passes through.
+    @Test func reasoningBudgetNilZeroAndValue() {
+        #expect(APIClient.chatPayload(model: "m", messages: msgs)["reasoning_budget"] == nil)
+        let zero = APIClient.chatPayload(model: "m", messages: msgs, reasoningBudget: 0)
+        #expect(zero["reasoning_budget"] as? Int == 0)
+        let capped = APIClient.chatPayload(model: "m", messages: msgs, reasoningBudget: 512)
+        #expect(capped["reasoning_budget"] as? Int == 512)
+    }
+
+    /// The chat toggle's one-way veto: nil (allow) is omitted, false is a real false.
+    @Test func enableThinkingOmittedOrFalse() {
+        #expect(APIClient.chatPayload(model: "m", messages: msgs)["enable_thinking"] == nil)
+        let off = APIClient.chatPayload(model: "m", messages: msgs, enableThinking: false)
+        #expect(off["enable_thinking"] as? Bool == false)
+    }
+
+    /// The remaining optionals encode under their wire names; empty stop is dropped.
+    @Test func optionalKeysEncodeUnderWireNames() {
+        let p = APIClient.chatPayload(model: "m", messages: msgs, temperature: 0.7,
+                                      maxTokens: 64, reasoningEffort: "low", topP: 0.9,
+                                      seed: 7, stop: ["END"])
+        #expect(p["temperature"] as? Double == 0.7)
+        #expect(p["max_tokens"] as? Int == 64)
+        #expect(p["reasoning_effort"] as? String == "low")
+        #expect(p["top_p"] as? Double == 0.9)
+        #expect(p["seed"] as? Int == 7)
+        #expect(p["stop"] as? [String] == ["END"])
+        let noStop = APIClient.chatPayload(model: "m", messages: msgs, stop: [])
+        #expect(noStop["stop"] == nil)
+    }
+}
+
+@Suite("Chat sessions")
+struct ChatSessionTests {
+    /// The per-conversation budget round-trips through the session files.
+    @Test func reasoningBudgetRoundTripsThroughTheStore() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chatstore-tests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ChatStore(directory: dir)
+        store.save(ChatSession(title: "budgeted",
+                               messages: [ChatMessage(role: .user, text: "hi")],
+                               reasoningBudget: 512))
+        store.save(ChatSession(title: "inheriting",
+                               messages: [ChatMessage(role: .user, text: "yo")]))
+        let sessions = store.list()
+        #expect(sessions.first(where: { $0.title == "budgeted" })?.reasoningBudget == 512)
+        #expect(sessions.first(where: { $0.title == "inheriting" })?.reasoningBudget == nil)
+    }
+
+    /// Session files written by builds that predate the field must still decode (= inherit).
+    @Test func oldSessionFilesDecodeWithNilBudget() throws {
+        let json = """
+        {"id": "00000000-0000-0000-0000-000000000001", "title": "old",
+         "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-01-01T00:00:00Z",
+         "messages": []}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let session = try decoder.decode(ChatSession.self, from: Data(json.utf8))
+        #expect(session.reasoningBudget == nil)
+    }
+}
+
+@Suite("Coalescer")
+@MainActor
+struct CoalescerTests {
+    /// Every wait is bounded (~2 s) so a regression fails fast instead of hanging the run.
+    private func wait(until condition: @escaping @MainActor () -> Bool) async -> Bool {
+        for _ in 0..<2000 {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return condition()
+    }
+
+    /// Latest-wins: schedule() calls arriving while a run is in flight coalesce into
+    /// exactly one re-run, and that re-run observes the newest state — a stale earlier
+    /// completion can never be the last word.
+    @Test func coalescesMidFlightSchedulesIntoOneRerunWithNewestState() async {
+        final class Box: @unchecked Sendable {
+            var value = 0
+            var seen: [Int] = []
+            var started = 0
+            var gate = false
+        }
+        let box = Box()
+        let coalescer = Coalescer {
+            box.started += 1
+            while !box.gate { try? await Task.sleep(nanoseconds: 1_000_000) }
+            box.seen.append(box.value)
+        }
+        box.value = 1
+        coalescer.schedule()
+        #expect(await wait { box.started == 1 })   // first run is genuinely in flight
+        box.value = 2
+        coalescer.schedule()                       // mid-flight: queues one re-run
+        box.value = 3
+        coalescer.schedule()                       // coalesces into the SAME re-run
+        box.gate = true
+        #expect(await wait { box.seen.count == 2 })
+        try? await Task.sleep(nanoseconds: 20_000_000)   // would surface a spurious 3rd run
+        #expect(box.seen.count == 2)               // one run + exactly one re-run
+        #expect(box.seen.last == 3)                // the re-run saw the newest state
+    }
+
+    /// Schedules landing BEFORE the first run starts fold into it — no redundant re-run,
+    /// and the single run still sees the newest state (inputs are read at send time).
+    @Test func preRunSchedulesFoldIntoTheFirstRun() async {
+        final class Box: @unchecked Sendable {
+            var value = 0
+            var seen: [Int] = []
+        }
+        let box = Box()
+        let coalescer = Coalescer { box.seen.append(box.value) }
+        box.value = 1
+        coalescer.schedule()
+        box.value = 2
+        coalescer.schedule()
+        #expect(await wait { !box.seen.isEmpty })
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        #expect(box.seen == [2])
     }
 }
 

--- a/src/mlx_dspark/anthropic_api.py
+++ b/src/mlx_dspark/anthropic_api.py
@@ -198,13 +198,26 @@ def _split_muse(text: str) -> tuple[str, str]:
     return reasoning.strip(), answer.strip()
 
 
-def split_thinking(text: str) -> tuple[str, str]:
+def split_thinking(text: str, in_thinking: str | None = None) -> tuple[str, str]:
     """``(reasoning, answer)``. Handles the self-opened form, the prefilled one (output that
     closes a block it never opened), and muse_glimmer's recipient-tagged channels. Returns
-    ``("", text)`` when there's no reasoning, and treats an unterminated block as all-reasoning."""
+    ``("", text)`` when there's no reasoning, and treats an unterminated block as all-reasoning.
+
+    ``in_thinking`` is the closing marker to expect when the chat template *prefilled* the
+    opener (see :func:`prompt_opens_thinking`): the text then STARTS inside the block, so a
+    missing closer means it is ALL reasoning. Without the hint that case is undetectable —
+    a thinking block truncated by ``max_tokens`` has neither opener nor closer in the text
+    and would misread as all-answer, leaking the chain of thought into content (the
+    streaming splitters have taken this hint since they existed; this is its non-streaming
+    counterpart)."""
     if _MUSE_MSG in text:            # muse Onyx-ATEM channels (the marker is muse-only)
         return _split_muse(text)
     s = text.lstrip()
+    if in_thinking:
+        end = s.find(in_thinking)
+        if end == -1:                # truncated before the closer ever arrived
+            return s, ""
+        return s[:end], s[end + len(in_thinking):].lstrip()
     for open_, close in _THINK_PAIRS:
         if s.startswith(open_):
             body = s[len(open_):]
@@ -500,11 +513,13 @@ def stop_reason(finish_reason: str, has_tool_use: bool) -> str:
 
 def build_message(text: str, *, model: str, input_tokens: int, output_tokens: int,
                   finish_reason: str, msg_id: str | None = None,
-                  thinking: bool = True, schemas: dict | None = None) -> dict:
+                  thinking: bool = True, schemas: dict | None = None,
+                  in_thinking: str | None = None) -> dict:
     """A complete non-streaming ``Message``, with reasoning and tool calls lifted out of
     ``text`` into their own content blocks. ``thinking=False`` discards the reasoning instead
-    of emitting a block for it; ``schemas`` types the XML tool-call form (see ``tools.py``)."""
-    reasoning, text = split_thinking(text)
+    of emitting a block for it; ``schemas`` types the XML tool-call form (see ``tools.py``);
+    ``in_thinking`` is the prefilled-opener hint (see :func:`split_thinking`)."""
+    reasoning, text = split_thinking(text, in_thinking=in_thinking)
     calls, cleaned = parse_tool_calls(text, schemas)
     content: list[dict] = []
     if reasoning and thinking:

--- a/src/mlx_dspark/cli.py
+++ b/src/mlx_dspark/cli.py
@@ -126,9 +126,20 @@ def cmd_generate(argv: list[str]) -> None:
                          "up to this length (default 32 = the measured M-series verify-width "
                          "plateau); set to the base (6) to disable. Speed-only, output "
                          "unchanged")
+    ap.add_argument("--reasoning-budget", type=int, default=0, metavar="N",
+                    help="max tokens a thinking model may spend inside <think>…</think> "
+                         "before the budget message + closing tag are force-injected so it "
+                         "answers (LM Studio Bionic-style; default 0 = off, opt in with "
+                         "e.g. 8192). Round-granular and once per generation; no effect on "
+                         "non-thinking output")
+    ap.add_argument("--reasoning-budget-message", default=None, metavar="TEXT",
+                    help='text injected when the reasoning budget fires '
+                         '(default: "I have to answer now.")')
     ap.add_argument("--no-chat-template", action="store_true")
     ap.add_argument("--no-stream", action="store_true")
     args = ap.parse_args(argv)
+    if args.reasoning_budget < 0:
+        ap.error("--reasoning-budget must be >= 0 (0 disables)")
 
     try:
         mode, target_repo, drafter_repo = resolve_mode(
@@ -181,6 +192,7 @@ def cmd_generate(argv: list[str]) -> None:
 
     apply_wide_gemm(target, drafter, target_repo=target_repo, min_rows=args.wide_gemm_min)
     on_text = None if args.no_stream else _emit
+    think_budget = args.reasoning_budget or None    # 0 disables
     print("\n" + "=" * 64)
     print(f"  ▶  {label}   ·   {target_repo.split('/')[-1]}")
     print("=" * 64)
@@ -215,6 +227,7 @@ def cmd_generate(argv: list[str]) -> None:
             confidence_threshold=args.confidence_threshold,
             temperature=args.temperature, top_p=args.top_p, top_k=args.top_k, seed=args.seed,
             apply_chat_template=not args.no_chat_template, on_text=on_text,
+            think_budget=think_budget, budget_message=args.reasoning_budget_message,
         )
         extra = f" · accept {res.mean_accept_len:.2f}/round · {res.target_forwards} target fwds"
         if res.lookup_rounds:
@@ -227,6 +240,7 @@ def cmd_generate(argv: list[str]) -> None:
             cap_controller=cap_controller,
             temperature=args.temperature, top_p=args.top_p, top_k=args.top_k,
             seed=args.seed, apply_chat_template=not args.no_chat_template, on_text=on_text,
+            think_budget=think_budget, budget_message=args.reasoning_budget_message,
         )
         extra = f" · accept {res.mean_accept_len:.2f}/round · {res.target_forwards} target fwds"
     elif args.mode == "lookup":
@@ -238,6 +252,7 @@ def cmd_generate(argv: list[str]) -> None:
             long_draft_tokens=max(cap, args.lookup_long_draft),
             temperature=args.temperature, top_p=args.top_p, top_k=args.top_k, seed=args.seed,
             apply_chat_template=not args.no_chat_template, on_text=on_text,
+            think_budget=think_budget, budget_message=args.reasoning_budget_message,
         )
         extra = f" · accept {res.mean_accept_len:.2f}/round · {res.target_forwards} target fwds"
     else:
@@ -245,6 +260,7 @@ def cmd_generate(argv: list[str]) -> None:
             target, tok, args.prompt, max_new_tokens=args.max_new_tokens,
             temperature=args.temperature, top_p=args.top_p, top_k=args.top_k, seed=args.seed,
             apply_chat_template=not args.no_chat_template, on_text=on_text,
+            think_budget=think_budget, budget_message=args.reasoning_budget_message,
         )
         extra = ""
     if cap_controller is not None:
@@ -330,6 +346,16 @@ def cmd_serve(argv: list[str]) -> None:
                          "(Qwen3.8-class reasoning_effort; templates that don't know the kwarg "
                          "ignore it). Clients can override per-request; /health reports whether "
                          "the loaded model supports it")
+    ap.add_argument("--reasoning-budget", type=int, default=0, metavar="N",
+                    help="server-default reasoning budget: max tokens a thinking model may "
+                         "spend inside <think>…</think> before the budget message + closing "
+                         "tag are force-injected so it answers (LM Studio Bionic-style; "
+                         "default 0 = off, opt in with e.g. 8192). Requests override via "
+                         "'reasoning_budget' (OpenAI) or thinking.budget_tokens (Anthropic); "
+                         "/health reports the default")
+    ap.add_argument("--reasoning-budget-message", default=None, metavar="TEXT",
+                    help='text injected when the reasoning budget fires '
+                         '(default: "I have to answer now.")')
     ap.add_argument("--no-prefix-cache", action="store_true",
                     help="disable multi-turn prefix caching (reuse the shared conversation "
                          "prefix's KV; on by default for dspark/lookup/baseline on dense or "
@@ -376,6 +402,8 @@ def cmd_serve(argv: list[str]) -> None:
                     help="spill the prefix cache to --prefix-cache-dir once it exceeds this many MB "
                          "of RAM (0 = never spill; requires --prefix-cache-dir)")
     args = ap.parse_args(argv)
+    if args.reasoning_budget < 0:
+        ap.error("--reasoning-budget must be >= 0 (0 disables)")
 
     md = _parse_max_draft(args.max_draft, ap)
     if md is None or md == "auto":
@@ -396,6 +424,8 @@ def cmd_serve(argv: list[str]) -> None:
         "confidence_threshold": args.confidence_threshold,
         "enable_thinking": False if args.no_thinking else None,
         "reasoning_effort": args.reasoning_effort,
+        "default_think_budget": args.reasoning_budget or None,   # 0 disables
+        "think_budget_message": args.reasoning_budget_message,
         "prefix_cache": not args.no_prefix_cache,
         "prefix_cache_dir": args.prefix_cache_dir,
         "prefix_cache_max_ram_mb": args.prefix_cache_max_ram_mb,

--- a/src/mlx_dspark/generate.py
+++ b/src/mlx_dspark/generate.py
@@ -57,6 +57,7 @@ class GenResult:
     finish_reason: str = "stop"  # "stop" (eos/stop-string) | "length" (hit max_new_tokens)
     lookup_rounds: int = 0       # rounds whose draft came from the free n-gram lookup
     logprobs: list | None = None  # per-token [{token_id, logprob, top:[(id, logprob), …]}], if requested
+    budget_forced: bool = False  # a reasoning budget fired and force-closed the thinking block
 
     @property
     def mean_accept_len(self) -> float:
@@ -404,6 +405,131 @@ def _finish_reason(out_ids: list[int], max_new_tokens: int, last_tok: int,
     return "length" if len(out_ids) >= max_new_tokens else "stop"
 
 
+# LM Studio's default message, matched deliberately so a reasoning budget behaves the way
+# its "Bionic" feature taught people to expect. The budget itself is opt-in at every layer
+# (CLI --reasoning-budget, per-request fields, the Mac app's checkbox — LM Studio ships its
+# checkbox unticked too); the loop functions default to think_budget=None (no injection),
+# so library callers keep byte-identical behavior.
+DEFAULT_BUDGET_MESSAGE = "I have to answer now."
+
+
+class ThinkBudget:
+    """Reasoning-budget tracker shared by every generation loop.
+
+    Watches the committed tokens for a thinking block (``<think>…</think>`` or the Gemma-4
+    channel pair) and, once ``budget`` tokens have been spent inside one, hands the loop the
+    token ids of a forced close — ``"\\n\\n{message}\\n" + closer + "\\n\\n"`` — to feed through
+    the target so the model is compelled to start answering. The loop owns the cache/context
+    mechanics; this class owns detection and the forced text.
+
+    Tracking is text-level (its own streaming detokenizer + a
+    :class:`~mlx_dspark.anthropic_api.ThinkingStreamSplitter` observer), because openers can
+    span several tokens and straddle round boundaries. A template-prefilled opener (Qwen3-2507
+    style — generation starts *inside* the block) is auto-detected from the prompt tail via
+    :func:`~mlx_dspark.anthropic_api.prompt_opens_thinking` unless ``in_thinking`` is given.
+    Fires at round granularity (an overshoot of one round's commit is possible) and at most
+    once per generation; a model that closes its own block first disarms the budget.
+    """
+
+    def __init__(self, tokenizer, budget: int, message: str | None = None,
+                 prompt_tail_ids: list[int] | None = None,
+                 eos_ids: set[int] | None = None,
+                 in_thinking: str | None = None):
+        from . import anthropic_api as A  # deferred: anthropic_api imports tools, not us
+
+        self._tok = tokenizer
+        self.budget = int(budget)
+        if self.budget <= 0:
+            raise ValueError(f"think budget must be a positive token count, got {budget!r}")
+        # "" is a real choice — close the block with no message; only None means default
+        self.message = DEFAULT_BUDGET_MESSAGE if message is None else message
+        self.eos_ids = eos_ids or set()
+        if in_thinking is None and prompt_tail_ids:
+            try:
+                in_thinking = A.prompt_opens_thinking(
+                    tokenizer.decode(list(prompt_tail_ids)[-8:]))
+            except Exception:  # noqa: BLE001 — tail decode is best-effort on exotic tokenizers
+                in_thinking = None
+        self._splitter = A.ThinkingStreamSplitter(in_thinking=in_thinking)
+        self._detok = _make_detokenizer(tokenizer)
+        self._n_fed = 0          # tokens of out_ids already fed to the detokenizer
+        self._n_chars = 0        # chars of detok.text already fed to the splitter (its
+        #                          .text is cumulative; the splitter wants increments)
+        self._start = 0 if in_thinking else None   # len(out_ids) when thinking began
+        self._done = False       # fired, or the model closed its own block
+        self.fired = False       # a forced close was actually handed out
+
+    def note(self, out_ids: list[int]) -> bool:
+        """Feed the newly committed tokens; True when the budget is exceeded inside a
+        thinking block and the loop should inject :meth:`take_forced_ids`. Idempotent —
+        repeated calls with unchanged ``out_ids`` return the same answer."""
+        if self._done:
+            return False
+        for t in out_ids[self._n_fed:]:
+            if t not in self.eos_ids:
+                self._detok.add_token(t)
+        self._n_fed = len(out_ids)
+        text = self._detok.text
+        new = text[self._n_chars:]
+        self._n_chars = len(text)
+        if new:
+            self._splitter.feed(new)
+        state = self._splitter.state
+        if state == "answer":     # closed its own block (or never opened one): disarm
+            self._done = True
+            return False
+        if state != "thinking":
+            return False
+        if self._start is None:   # opener completed somewhere in this round's commit
+            self._start = len(out_ids)
+        if len(out_ids) - self._start < self.budget:
+            return False
+        # Don't fire while the splitter's held-back tail could still complete the closer —
+        # the model may be mid-`</think>` right now; the next round settles it either way
+        # (more thinking text -> fire then; the closer completes -> disarmed).
+        buf, close = self._splitter.buf, self._splitter.close
+        return not (buf and any(buf.endswith(close[:i]) for i in range(1, len(close))))
+
+    @property
+    def close_marker(self) -> str:
+        """The family-correct closing marker (known once the opener has been seen, or from
+        a prefilled opener; the Qwen ``</think>`` default otherwise)."""
+        return self._splitter.close
+
+    def _encode(self, text: str) -> list[int]:
+        try:
+            ids = self._tok.encode(text, add_special_tokens=False)
+        except TypeError:         # tokenizer without the kwarg (same retry as encode_messages)
+            ids = self._tok.encode(text)
+        return [int(i) for i in ids]
+
+    def _closer_ids(self) -> list[int]:
+        # `</think>` is a single added token on Qwen; resolve it like eos_token_ids does,
+        # falling back to a plain-text encode (Gemma's `<channel|>` etc.).
+        unk = getattr(self._tok, "unk_token_id", None)
+        try:
+            i = self._tok.convert_tokens_to_ids(self.close_marker)
+        except Exception:  # noqa: BLE001 — tokenizers raise various types for unknown tokens
+            i = None
+        if isinstance(i, int) and i >= 0 and i != unk:
+            return [i]
+        return self._encode(self.close_marker)
+
+    def take_forced_ids(self, remaining: int) -> list[int]:
+        """Token ids of the forced close, or ``[]`` when fewer than ``remaining`` tokens are
+        left (the closer must never be truncated — generation then just runs to the cap as it
+        would today). A non-empty return arms once-only and sets :attr:`fired`."""
+        ids = (self._encode("\n\n" + self.message + "\n" if self.message else "\n")
+               + self._closer_ids()
+               + self._encode("\n\n"))
+        ids = [i for i in ids if i not in self.eos_ids]  # a forced eos would end the turn
+        if not ids or remaining < len(ids):
+            return []
+        self._done = True
+        self.fired = True
+        return ids
+
+
 def greedy_generate(
     target_model,
     tokenizer,
@@ -422,6 +548,8 @@ def greedy_generate(
     seed: int | None = None,
     apply_chat_template: bool = True,
     stop: list[str] | None = None,
+    think_budget: int | None = None,
+    budget_message: str | None = None,
     on_text=None,
     on_round=None,
     on_prefill=None,
@@ -433,12 +561,17 @@ def greedy_generate(
     ``presence_penalty`` / ``frequency_penalty`` (OpenAI) penalize the completion's own tokens.
 
     ``prompt_ids`` overrides ``prompt`` with a pre-tokenized prompt (the server passes a full
-    multi-turn transcript this way); ``stop`` adds string stop-sequences (OpenAI ``stop``)."""
+    multi-turn transcript this way); ``stop`` adds string stop-sequences (OpenAI ``stop``).
+    ``think_budget`` caps reasoning: past that many tokens inside a thinking block, a
+    :class:`ThinkBudget` forced close (``budget_message`` + the closing marker) is fed through
+    the model and generation continues into the answer."""
     if seed is not None:
         mx.random.seed(seed)
     eos_ids = eos_token_ids(tokenizer)
     ids = prompt_ids if prompt_ids is not None else encode_prompt(
         tokenizer, prompt, use_chat=apply_chat_template)
+    tb = (ThinkBudget(tokenizer, think_budget, budget_message,
+                      prompt_tail_ids=ids, eos_ids=eos_ids) if think_budget else None)
     if cache is None:                                  # fresh, or reuse a prefix-cached one
         cache = target_model.make_cache()
         reuse_len = 0
@@ -454,6 +587,8 @@ def greedy_generate(
     out_ids: list[int] = []
     pen = _Penalizer(presence_penalty, frequency_penalty)
     lp_list: list | None = [] if logprobs is not None else None
+    accepts: list[int] = []   # per-forward committed counts: 1 per plain step, len(forced)
+    #                           for a budget injection — so rounds/forwards stay truthful
 
     if pen.active or logprobs is not None:
         # Sequential decode: needed when penalties are on (penalty state must include the just-
@@ -465,6 +600,7 @@ def greedy_generate(
                     if pen.active else 0.0)
             nxt = int(_sample_arr(logits_row - pen0, temperature, top_p, top_k).item())
             out_ids.append(nxt)
+            accepts.append(1)
             pen.add([nxt])
             if on_round is not None:
                 on_round(drafted=0, accepted=0, committed=1, cap=0, source="plain")
@@ -474,6 +610,27 @@ def greedy_generate(
             if len(out_ids) >= max_new_tokens or nxt in eos_ids or st.stopped:
                 break
             logits_row = target_model.plain(mx.array([[nxt]]), cache)[0, -1]
+            if tb is not None and tb.note(out_ids):
+                forced = tb.take_forced_ids(max_new_tokens - len(out_ids))
+                if forced:
+                    # cache holds prompt + out_ids exactly here; one forward commits the
+                    # whole forced close and leaves logits_row at the post-close position
+                    full = target_model.plain(mx.array([forced]), cache)
+                    if lp_list is not None:
+                        # row predicting forced[i]: the pre-injection row, then full[:-1]
+                        rows = mx.concatenate([logits_row[None, :], full[0, :-1]])
+                        lp_list.extend(_logprobs_for_block(rows, forced, logprobs))
+                    out_ids.extend(forced)
+                    accepts.append(len(forced))
+                    pen.add(forced)
+                    if on_round is not None:
+                        on_round(drafted=0, accepted=0, committed=len(forced), cap=0,
+                                 source="plain")
+                    st.update(out_ids)
+                    nxt = forced[-1]
+                    if len(out_ids) >= max_new_tokens or st.stopped:
+                        break
+                    logits_row = full[0, -1]
     else:
         # Pipelined decode (mlx-lm style): schedule step t+1 on the GPU *before* syncing on
         # step t's token, so detokenize/emit overlaps GPU compute instead of serializing with
@@ -487,6 +644,7 @@ def greedy_generate(
             mx.async_eval(y_next)
             nxt = int(y.item())
             out_ids.append(nxt)
+            accepts.append(1)
             # Baseline has no speculation, but reporting each step keeps the live view's
             # event shape identical across modes — which is what makes a side-by-side race
             # between baseline and dspark a single rendering path.
@@ -495,6 +653,24 @@ def greedy_generate(
             st.update(out_ids)
             if len(out_ids) >= max_new_tokens or nxt in eos_ids or st.stopped:
                 break
+            if tb is not None and tb.note(out_ids):
+                forced = tb.take_forced_ids(max_new_tokens - len(out_ids))
+                if forced:
+                    # cache holds prompt + out_ids here; y_next was sampled but never fed,
+                    # so discarding it costs only this round's pipelining overlap
+                    logits = target_model.plain(mx.array([forced]), cache)
+                    out_ids.extend(forced)
+                    accepts.append(len(forced))
+                    if on_round is not None:
+                        on_round(drafted=0, accepted=0, committed=len(forced), cap=0,
+                                 source="plain")
+                    st.update(out_ids)
+                    nxt = forced[-1]
+                    if len(out_ids) >= max_new_tokens or st.stopped:
+                        break
+                    y = _sample_arr(logits[0, -1], temperature, top_p, top_k)
+                    mx.async_eval(y)
+                    continue
             y = y_next
     st.flush()
 
@@ -504,12 +680,13 @@ def greedy_generate(
         text=text,
         token_ids=out_ids,
         num_tokens=len(out_ids),
-        num_rounds=len(out_ids),
-        accept_lengths=[1] * len(out_ids),
-        target_forwards=len(out_ids),
+        num_rounds=len(accepts),
+        accept_lengths=accepts,
+        target_forwards=len(accepts),
         seconds=secs,
         finish_reason=_finish_reason(out_ids, max_new_tokens, nxt, eos_ids, st),
         logprobs=lp_list,
+        budget_forced=tb.fired if tb is not None else False,
     )
 
 
@@ -533,6 +710,8 @@ def dflash_generate(
     apply_chat_template: bool = True,
     seed: int | None = None,
     stop: list[str] | None = None,
+    think_budget: int | None = None,
+    budget_message: str | None = None,
     on_text=None,
     on_round=None,
     on_prefill=None,
@@ -577,6 +756,8 @@ def dflash_generate(
 
     ids = prompt_ids if prompt_ids is not None else encode_prompt(
         tokenizer, prompt, use_chat=apply_chat_template)
+    tb = (ThinkBudget(tokenizer, think_budget, budget_message,
+                      prompt_tail_ids=ids, eos_ids=eos_ids) if think_budget else None)
     # Prefix caching (checkpoint mode, server path): the caller may pass a target cache
     # already holding the first `reuse_len` tokens plus a DFlashCtxWindow of the drafter's
     # projected ctx rows ending at that boundary — then only the suffix is prefilled and
@@ -671,6 +852,27 @@ def dflash_generate(
 
     st.update(out_ids)
     while len(out_ids) < max_new_tokens and pending not in eos_ids and not st.stopped:
+        if tb is not None and tb.note(out_ids):
+            forced = tb.take_forced_ids(max_new_tokens - len(out_ids))
+            if forced:
+                # ---- forced close (reasoning budget): one verify commits the whole close,
+                # forced[-1] becomes the new `pending` (committed, not yet in cache). The
+                # current pending_ctx rows haven't been appended to the draft cache yet
+                # (the *next* draft call does that), so the forced rows are CONCATENATED —
+                # overwriting would drop committed drafter context.
+                v_logits, v_fused = target_model.verify(
+                    mx.array([[pending] + forced[:-1]]), cache, tap)
+                target_model.rollback(cache, 0, [])   # hybrid targets: clear capture stash
+                pending_ctx = mx.concatenate([pending_ctx, v_fused], axis=1)
+                out_ids.extend(forced)
+                pending = forced[-1]
+                target_forwards += 1
+                accept_lengths.append(len(forced))
+                if on_round is not None:
+                    on_round(drafted=0, accepted=0, committed=len(forced), cap=0,
+                             source="plain")
+                st.update(out_ids)
+                continue
         # ---- draft full-width block; feeding pending_ctx appends exactly the just-
         # committed positions to the draft KV cache (DFlash caches only ctx KV, never
         # block KV) -> correct absolute RoPE offsets, no trim needed.
@@ -762,6 +964,7 @@ def dflash_generate(
         target_forwards=target_forwards,
         seconds=secs,
         finish_reason=_finish_reason(out_ids, max_new_tokens, pending, eos_ids, st),
+        budget_forced=tb.fired if tb is not None else False,
     )
 
 
@@ -945,6 +1148,8 @@ def speculative_generate(
     seed: int | None = None,
     apply_chat_template: bool = True,
     stop: list[str] | None = None,
+    think_budget: int | None = None,
+    budget_message: str | None = None,
     on_text=None,
     on_round=None,
     on_prefill=None,
@@ -990,6 +1195,10 @@ def speculative_generate(
     scaling when long drafts keep getting chopped early (insertion-heavy edits) and probes
     back in. Set equal to ``lookup_max_draft`` to disable. Speed-only; output unchanged
     (see :meth:`NGramIndex.propose`).
+
+    ``think_budget`` caps reasoning (see :class:`ThinkBudget`): past that many tokens inside
+    a thinking block, ``budget_message`` + the closing marker are force-fed through one
+    verify round and generation continues into the answer. Round-granular and once-only.
     """
     if seed is not None:
         mx.random.seed(seed)
@@ -1012,6 +1221,8 @@ def speculative_generate(
     # --- tokenize prompt ---
     ids = prompt_ids if prompt_ids is not None else encode_prompt(
         tokenizer, prompt, use_chat=apply_chat_template)
+    tb = (ThinkBudget(tokenizer, think_budget, budget_message,
+                      prompt_tail_ids=ids, eos_ids=eos_ids) if think_budget else None)
 
     # Prefix caching: the caller may pass a target cache + drafter ctx already holding the
     # first `reuse_len` tokens (a shared conversation prefix); then we only prefill the
@@ -1063,6 +1274,36 @@ def speculative_generate(
 
     st.update(out_ids)
     while len(out_ids) < max_new_tokens and pending not in eos_ids and not st.stopped:
+        if tb is not None and tb.note(out_ids):
+            forced = tb.take_forced_ids(max_new_tokens - len(out_ids))
+            if forced:
+                # ---- forced close (reasoning budget) ----
+                # One verify feeds [pending] + forced[:-1] (= len(forced) rows) and commits
+                # everything unconditionally; forced[-1] becomes the new `pending` (committed,
+                # not yet in cache), so the round invariant is untouched. Row i of v_logits
+                # predicts forced[i]; v_fused rows are exactly the tokens just fed.
+                v_logits, v_fused = target_model.verify(
+                    mx.array([[pending] + forced[:-1]]), cache, tap)
+                target_model.rollback(cache, 0, [])   # hybrid targets: clear capture stash
+                drafter.update_context(v_fused, ctx_offset=n_cached, ctx_caches=ctx_caches)
+                n_cached += len(forced)
+                mx.async_eval([c.k for c in ctx_caches])
+                out_ids.extend(forced)
+                pen.add(forced)
+                if lp_list is not None:
+                    lp_list.extend(
+                        _logprobs_for_block(v_logits[0][:len(forced)], forced, logprobs))
+                if index is not None:
+                    index.extend(forced)
+                pending = forced[-1]
+                target_forwards += 1
+                accept_lengths.append(len(forced))
+                if on_round is not None:
+                    on_round(drafted=0, accepted=0, committed=len(forced), cap=0,
+                             source="plain")
+                st.update(out_ids)
+                _rt = time.perf_counter()   # don't bill the injection to the cap controller
+                continue
         lk_draft = []
         if index is not None:
             # clamp to the remaining budget: no verify width wasted past max_new_tokens
@@ -1111,7 +1352,8 @@ def speculative_generate(
                 pending = nxt
                 st.update(out_ids)
                 if (steps <= 0 or len(out_ids) >= max_new_tokens or pending in eos_ids
-                        or st.stopped or cap_controller.cap != 0):
+                        or st.stopped or cap_controller.cap != 0
+                        or (tb is not None and tb.note(out_ids))):
                     break
                 y = nxt_arr.reshape(1, 1)
                 logits, fused = target_model.verify(y, cache, tap)
@@ -1313,4 +1555,5 @@ def speculative_generate(
         finish_reason=_finish_reason(out_ids, max_new_tokens, pending, eos_ids, st),
         lookup_rounds=lookup_rounds,
         logprobs=lp_list,
+        budget_forced=tb.fired if tb is not None else False,
     )

--- a/src/mlx_dspark/lookup.py
+++ b/src/mlx_dspark/lookup.py
@@ -30,6 +30,7 @@ import mlx.core as mx
 
 from .generate import (
     GenResult,
+    ThinkBudget,
     _finish_reason,
     _make_target_cache,
     _pick,
@@ -158,6 +159,8 @@ def lookup_generate(
     seed: int | None = None,
     apply_chat_template: bool = True,
     stop: list[str] | None = None,
+    think_budget: int | None = None,
+    budget_message: str | None = None,
     on_text=None,
     on_round=None,
     on_prefill=None,
@@ -173,12 +176,18 @@ def lookup_generate(
     ``long_draft_tokens``: match-scaled long-draft ceiling — a deep context match (a real
     copy run) earns drafts up to this length; see :meth:`NGramIndex.propose`. Set equal to
     ``max_draft_tokens`` to disable.
+
+    ``think_budget`` caps reasoning (see :class:`~mlx_dspark.generate.ThinkBudget`): past
+    that many tokens inside a thinking block, ``budget_message`` + the closing marker are
+    force-fed through one verify round and generation continues into the answer.
     """
     if seed is not None:
         mx.random.seed(seed)
     eos_ids = eos_token_ids(tokenizer)
     ids = prompt_ids if prompt_ids is not None else encode_prompt(
         tokenizer, prompt, use_chat=apply_chat_template)
+    tb = (ThinkBudget(tokenizer, think_budget, budget_message,
+                      prompt_tail_ids=ids, eos_ids=eos_ids) if think_budget else None)
     if cache is None:
         cache = _make_target_cache(target_model)
         reuse_len = 0
@@ -204,6 +213,23 @@ def lookup_generate(
 
     st.update(out_ids)
     while len(out_ids) < max_new_tokens and pending not in eos_ids and not st.stopped:
+        if tb is not None and tb.note(out_ids):
+            forced = tb.take_forced_ids(max_new_tokens - len(out_ids))
+            if forced:
+                # ---- forced close (reasoning budget): one verify commits the whole close;
+                # forced[-1] becomes the new `pending` (committed, not yet in cache).
+                target_model.verify(mx.array([[pending] + forced[:-1]]), cache, None)
+                target_model.rollback(cache, 0, [])   # hybrid targets: clear capture stash
+                out_ids.extend(forced)
+                index.extend(forced)
+                pending = forced[-1]
+                target_forwards += 1
+                accept_lengths.append(len(forced))
+                if on_round is not None:
+                    on_round(drafted=0, accepted=0, committed=len(forced), cap=0,
+                             source="plain")
+                st.update(out_ids)
+                continue
         # clamp to the remaining budget: no verify width wasted past max_new_tokens
         draft = index.propose(
             long_draft=long_draft_tokens if gate.allowed else None,
@@ -271,4 +297,5 @@ def lookup_generate(
         target_forwards=target_forwards,
         seconds=secs,
         finish_reason=_finish_reason(out_ids, max_new_tokens, pending, eos_ids, st),
+        budget_forced=tb.fired if tb is not None else False,
     )

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -81,6 +81,15 @@ def _reasoning_effort(value) -> str:
     return value.lower()
 
 
+def _think_budget(value, field: str = "reasoning_budget") -> int | None:
+    """Normalize a client reasoning-budget value: a non-negative integer, where 0 means
+    "explicitly disabled" (returned as None). Anything else — bool, float, string, negative —
+    raises ValueError so the handler can turn a malformed request into a 400, not a 500."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer, got {value!r}")
+    return value or None
+
+
 def _target_config(target_repo: str) -> dict | None:
     """The target's ``config.json`` as a dict, or ``None`` when it can't be read."""
     try:
@@ -238,6 +247,8 @@ class Engine:
         sampling_defaults: dict | None = None,
         default_max_tokens: int = 2048,
         max_tokens_cap: int = 32768,
+        default_think_budget: int | None = None,
+        think_budget_message: str | None = None,
         prefix_cache_slots: int = 2,
         prefix_cache_rungs: int = 8192,
         lookup_drafts: bool = True,
@@ -268,6 +279,12 @@ class Engine:
         self.sampling_defaults = dict(sampling_defaults or {})
         self.default_max_tokens = default_max_tokens
         self.max_tokens_cap = max_tokens_cap
+        # Reasoning budget (LM Studio "Bionic"-style; see generate.ThinkBudget). 0/None =
+        # disabled server-wide; requests may override either way (reasoning_budget /
+        # Anthropic thinking.budget_tokens). Never applied to muse-format models.
+        # An empty message is meaningful (close the block with no message) — keep it.
+        self.default_think_budget = default_think_budget or None
+        self.think_budget_message = think_budget_message
         self.prefix_cache_slots = max(1, prefix_cache_slots)
         self.prefix_cache_rungs = max(0, prefix_cache_rungs)  # interior-snapshot spacing
         #   (tokens) for checkpoint-mode prefix caching; 0 disables rungs (see prefix_cache)
@@ -433,6 +450,8 @@ class Engine:
         prefix_cache_max_ram_mb: int = 0,
         default_max_tokens: int = 2048,
         max_tokens_cap: int = 32768,
+        default_think_budget: int | None = None,   # reasoning budget; 0/None = off
+        think_budget_message: str | None = None,   # text injected when the budget fires
         default_temperature: float | None = None,
         default_top_p: float | None = None,
         default_top_k: int | None = None,
@@ -450,6 +469,14 @@ class Engine:
     ) -> Engine:
         if mode != "auto" and mode not in MODES:
             raise ValueError(f"mode must be one of {MODES} or 'auto', got {mode!r}")
+        # Boundary-validate the budget knobs here so a bad value is a clear error at load
+        # time (CLI: argparse error; /admin/load: 400) — a negative default reaching
+        # ThinkBudget would force-close every thinking block instantly.
+        if default_think_budget is not None:
+            default_think_budget = _think_budget(default_think_budget,
+                                                 field="default_think_budget")
+        if think_budget_message is not None and not isinstance(think_budget_message, str):
+            raise ValueError("think_budget_message must be a string")
         # "auto" picks the best available speculation for this target (dspark -> dflash ->
         # drafter-free lookup), so any model repo serves without extra flags.
         mode, target_repo, drafter_repo = resolve_mode(model, mode=mode, drafter=drafter,
@@ -586,6 +613,8 @@ class Engine:
                    cap_controller=cap_controller,
                    sampling_defaults=sampling_defaults,
                    default_max_tokens=default_max_tokens, max_tokens_cap=max_tokens_cap,
+                   default_think_budget=default_think_budget,
+                   think_budget_message=think_budget_message,
                    prefix_cache_slots=prefix_cache_slots,
                    prefix_cache_rungs=prefix_cache_rungs, lookup_drafts=lookup_drafts,
                    lookup_long_draft=lookup_long_draft,
@@ -609,12 +638,20 @@ class Engine:
         logprobs: int | None = None,
         stop: list[str] | None,
         seed: int | None,
+        think_budget: int | None = None,
+        budget_message: str | None = None,
+        budget_explicit: bool = True,    # batching hint only (see BatchEngine._run). True by
+        #                                  default so a direct caller's think_budget is always
+        #                                  enforced; the HTTP handlers pass False for a budget
+        #                                  that came from the SERVER default, which batched
+        #                                  rows may skip rather than forfeit batching
         on_text=None,
     ) -> GenResult:
         # hop onto the single generation thread (keeps all MLX/cache work same-thread)
         return self._executor.submit(
             self._generate_impl, prompt_ids, max_tokens, temperature, top_p, top_k,
-            stop, seed, on_text, presence_penalty, frequency_penalty, logprobs).result()
+            stop, seed, on_text, presence_penalty, frequency_penalty, logprobs,
+            think_budget, budget_message).result()
 
     def _with_slow_round_log(self, inner, n_prompt: int):
         """Wrap a per-round callback with a stall detector: any gap over
@@ -639,7 +676,7 @@ class Engine:
 
     def _generate_impl(self, prompt_ids, max_tokens, temperature, top_p, top_k, stop, seed,
                        on_text, presence_penalty=0.0, frequency_penalty=0.0,
-                       logprobs=None) -> GenResult:
+                       logprobs=None, think_budget=None, budget_message=None) -> GenResult:
         on_round = self._with_slow_round_log(
             RoundRecorder(self.rounds, uuid.uuid4().hex[:8], self.mode), len(prompt_ids))
         # prefix caching: reuse the shared conversation prefix's KV (all modes; dflash is
@@ -702,6 +739,7 @@ class Engine:
                     temperature=temperature, top_p=top_p, top_k=top_k,
                     presence_penalty=presence_penalty, frequency_penalty=frequency_penalty,
                     logprobs=logprobs, seed=seed, stop=stop, on_text=on_text,
+                    think_budget=think_budget, budget_message=budget_message,
                     on_round=on_round, on_prefill=on_prefill, prefill_marks=prefill_marks,
                 )
             elif self.mode == "dflash":
@@ -711,8 +749,9 @@ class Engine:
                     max_new_tokens=max_tokens, max_draft_tokens=eff_cap,
                     cap_controller=self.cap_controller,
                     temperature=temperature, top_p=top_p, top_k=top_k,
-                    seed=seed, stop=stop, on_text=on_text, on_round=on_round,
-                    on_prefill=on_prefill, prefill_marks=prefill_marks,
+                    seed=seed, stop=stop, on_text=on_text,
+                    think_budget=think_budget, budget_message=budget_message,
+                    on_round=on_round, on_prefill=on_prefill, prefill_marks=prefill_marks,
                 )
             elif self.mode == "lookup":
                 res = lookup_generate(
@@ -721,8 +760,9 @@ class Engine:
                     max_new_tokens=max_tokens, max_draft_tokens=self.max_draft_tokens or 6,
                     long_draft_tokens=max(self.max_draft_tokens or 6, self.lookup_long_draft),
                     temperature=temperature, top_p=top_p, top_k=top_k,
-                    seed=seed, stop=stop, on_text=on_text, on_round=on_round,
-                    on_prefill=on_prefill, prefill_marks=prefill_marks,
+                    seed=seed, stop=stop, on_text=on_text,
+                    think_budget=think_budget, budget_message=budget_message,
+                    on_round=on_round, on_prefill=on_prefill, prefill_marks=prefill_marks,
                 )
             else:
                 res = greedy_generate(
@@ -731,8 +771,9 @@ class Engine:
                     max_new_tokens=max_tokens, temperature=temperature, top_p=top_p,
                     top_k=top_k, presence_penalty=presence_penalty,
                     frequency_penalty=frequency_penalty, logprobs=logprobs, seed=seed,
-                    stop=stop, on_text=on_text, on_round=on_round,
-                    on_prefill=on_prefill, prefill_marks=prefill_marks,
+                    stop=stop, on_text=on_text,
+                    think_budget=think_budget, budget_message=budget_message,
+                    on_round=on_round, on_prefill=on_prefill, prefill_marks=prefill_marks,
                 )
         except BaseException:                     # never leave a desynced cache behind
             if self.prefix is not None:
@@ -1149,12 +1190,15 @@ class BatchEngine:
     # --- public API (mirrors Engine.generate) ---
     def generate(self, prompt_ids, *, max_tokens, temperature, top_p=1.0, top_k=0,
                  presence_penalty=0.0, frequency_penalty=0.0, logprobs=None, stop=None,
-                 seed=None, on_text=None) -> GenResult:
+                 seed=None, think_budget=None, budget_message=None, budget_explicit=True,
+                 on_text=None) -> GenResult:
         job = _Job(prompt_ids,
                    {"max_tokens": max_tokens, "temperature": temperature,
                     "top_p": top_p, "top_k": top_k, "presence_penalty": presence_penalty,
                     "frequency_penalty": frequency_penalty, "logprobs": logprobs,
-                    "stop": stop or [], "seed": seed}, on_text)
+                    "stop": stop or [], "seed": seed,
+                    "think_budget": think_budget, "budget_message": budget_message,
+                    "budget_explicit": budget_explicit}, on_text)
         self._q.put(job)
         job.done.wait()
         if job.error is not None:
@@ -1201,8 +1245,14 @@ class BatchEngine:
         groups: dict = {}
         for j in batch:
             p = j.params
-            if p["presence_penalty"] or p["frequency_penalty"] or p["logprobs"] is not None:
-                self._run_serial(j)           # penalties/logprobs: serial (batched kernels lack them)
+            if (p["presence_penalty"] or p["frequency_penalty"] or p["logprobs"] is not None
+                    or (p.get("think_budget") and p.get("budget_explicit"))):
+                # penalties/logprobs: serial (batched kernels lack them). An EXPLICITLY
+                # requested reasoning budget is serial too — ragged per-row injection can't
+                # share a batched forward. The server-DEFAULT budget deliberately does NOT
+                # forfeit batching: batched rows just run without enforcement (a lone
+                # request still goes serial below, where the budget applies as usual).
+                self._run_serial(j)
                 continue
             key = (p["temperature"], p["top_p"], p["top_k"])
             groups.setdefault(key, []).append(j)
@@ -1221,7 +1271,8 @@ class BatchEngine:
     def _batchable_greedy(job: _Job) -> bool:
         p = job.params
         return (not p["presence_penalty"] and not p["frequency_penalty"]
-                and p["logprobs"] is None and not p["temperature"])
+                and p["logprobs"] is None and not p["temperature"]
+                and not (p.get("think_budget") and p.get("budget_explicit")))
 
     def _admit(self, slots, job: _Job) -> bool:
         try:
@@ -1300,7 +1351,8 @@ class BatchEngine:
             job.result = self.engine._generate_impl(
                 job.prompt_ids, p["max_tokens"], p["temperature"], p["top_p"], p["top_k"],
                 p["stop"], p["seed"], job.on_text, p["presence_penalty"], p["frequency_penalty"],
-                p["logprobs"])
+                p["logprobs"], think_budget=p.get("think_budget"),
+                budget_message=p.get("budget_message"))
             self.batch_stats["serial_requests"] += 1
         except BaseException as e:  # noqa: BLE001
             job.error = e
@@ -1358,6 +1410,37 @@ def maybe_batch_engine(engine: Engine, max_batch: int):
     if not ok(engine.target):
         return engine
     return BatchEngine(engine, max_batch=max_batch)
+
+
+def _resolve_engine(obj):
+    """The innermost Engine behind a BatchEngine wrapper. Reasoning-config writes must land
+    on the real Engine: a ``setattr`` on a delegating wrapper would create a shadowing
+    instance attribute that permanently breaks its ``__getattr__`` forwarding."""
+    return obj.engine if isinstance(obj, BatchEngine) else obj
+
+
+def _apply_reasoning_config(eng, patch: dict) -> None:
+    """Apply a validated /admin/config patch to a live engine. The request handlers read
+    these attributes per request, so the change is effective immediately — no reload."""
+    eng = _resolve_engine(eng)
+    if "enable_thinking" in patch:
+        v = patch["enable_thinking"]
+        if v is None:                # null clears the override: the template's own default
+            eng.template_defaults.pop("enable_thinking", None)
+        else:                        # explicit True/False both stored — True must WIN over
+            eng.template_defaults["enable_thinking"] = v   # a template that defaults off
+    if "reasoning_budget" in patch:
+        eng.default_think_budget = patch["reasoning_budget"]
+    if "reasoning_budget_message" in patch:
+        eng.think_budget_message = patch["reasoning_budget_message"]
+
+
+def _reasoning_config_of(eng) -> dict:
+    """The effective reasoning config of a live engine, in /admin/config response shape."""
+    eng = _resolve_engine(eng)
+    return {"enable_thinking": eng.template_defaults.get("enable_thinking"),
+            "reasoning_budget": eng.default_think_budget,
+            "reasoning_budget_message": eng.think_budget_message}
 
 
 class EngineHolder:
@@ -1431,6 +1514,33 @@ class EngineHolder:
                 if inner is not None and inner is not old and hasattr(inner, "close"):
                     inner.close()
             return self.status()
+
+    def configure(self, patch: dict) -> dict:
+        """Apply validated reasoning-config values (see the ``/admin/config`` handler) to the
+        stored load kwargs AND the live engine — no model reload; the request handlers read
+        these engine attributes per request, so the change is effective immediately. Works in
+        the no-model state too (kwargs only, so the next load carries the values).
+
+        Deliberately lock-free, matching the codebase: the kwargs write comes FIRST, so any
+        swap that starts after this call loads with the new values; a patch landing inside an
+        in-flight swap's copy-to-publish window can be missed by THAT engine (the next swap
+        still carries it). Accepted single-writer limitation — in practice the app is the
+        only writer, and it disables its Reasoning card while a load is in flight.
+        """
+        if "enable_thinking" in patch:
+            self._load_kwargs["enable_thinking"] = patch["enable_thinking"]
+        if "reasoning_budget" in patch:
+            self._load_kwargs["default_think_budget"] = patch["reasoning_budget"]
+        if "reasoning_budget_message" in patch:
+            self._load_kwargs["think_budget_message"] = patch["reasoning_budget_message"]
+        eng = self._engine
+        if eng is not None:
+            _apply_reasoning_config(eng, patch)
+            return _reasoning_config_of(eng)
+        kw = self._load_kwargs
+        return {"enable_thinking": kw.get("enable_thinking"),
+                "reasoning_budget": kw.get("default_think_budget"),
+                "reasoning_budget_message": kw.get("think_budget_message")}
 
     def swap(self, *, model: str, mode: str | None = None,
              max_draft: int | str | None = None,
@@ -1685,6 +1795,17 @@ def make_handler(engine: Engine, api_key: str | None):
                         # non-null while a first-time load is fetching weights:
                         # {repo, bytes_done, bytes_total} — cancel with /admin/load/cancel
                         "download": status.get("download"),
+                        # the configured reasoning defaults survive no-model/mid-swap states
+                        # (they live in the load kwargs, not on the engine)
+                        "reasoning_budget": (getattr(engine, "_load_kwargs", None)
+                                             or {}).get("default_think_budget"),
+                        "reasoning_budget_message": (getattr(engine, "_load_kwargs", None)
+                                                     or {}).get("think_budget_message"),
+                        "enable_thinking": (getattr(engine, "_load_kwargs", None)
+                                            or {}).get("enable_thinking"),
+                        # capability flag: this server accepts POST /admin/config (a client
+                        # must gate its reasoning controls on it — older engines 404)
+                        "admin_config": True,
                         "error": status["error"]})
                 # max_draft as a string ("auto" or the pinned/derived cap) so a client can
                 # show the configured knob, not just infer it from round telemetry.
@@ -1726,6 +1847,25 @@ def make_handler(engine: Engine, api_key: str | None):
                         getattr(engine, "supports_reasoning_effort", False)),
                     "reasoning_effort": getattr(engine, "template_defaults", {}).get(
                         "reasoning_effort"),
+                    # Whether the LOADED model honors reasoning budgets at all — muse-format
+                    # models don't (the request path skips think_budget for them), so a
+                    # client should gate a per-request budget control on this, not on
+                    # admin_config (which is about the server, not the model).
+                    "supports_reasoning_budget": not bool(getattr(engine, "is_muse",
+                                                                  False)),
+                    # Server-default reasoning budget (tokens of thinking before a forced
+                    # close; null = disabled). Requests override via `reasoning_budget`
+                    # (OpenAI) or `thinking.budget_tokens` (Anthropic).
+                    "reasoning_budget": getattr(engine, "default_think_budget", None),
+                    "reasoning_budget_message": getattr(engine, "think_budget_message",
+                                                        None),
+                    # Server-default thinking switch: true/false = an explicit override,
+                    # null = the chat template's own default.
+                    "enable_thinking": getattr(engine, "template_defaults", {}).get(
+                        "enable_thinking"),
+                    # capability flag: this server accepts POST /admin/config (a client
+                    # must gate its reasoning controls on it — older engines 404)
+                    "admin_config": True,
                 })
             if route == "/admin/status":
                 if isinstance(engine, EngineHolder):
@@ -1850,6 +1990,50 @@ def make_handler(engine: Engine, api_key: str | None):
                 return self._send_error(500, f"could not load {model!r}: "
                                              f"{type(e).__name__}: {e}", "api_error")
             return self._send_json(200, status)
+
+        def _config(self, req: dict):
+            """``POST /admin/config`` — set the server-default reasoning knobs on the LIVE
+            engine, no model reload (the generation handlers read them per request). Keys
+            (all optional; omitted = unchanged; an empty body is a plain read-back, which
+            doubles as a capability probe):
+
+              enable_thinking           true | false | null (null clears the override)
+              reasoning_budget          non-negative int; 0 disables
+              reasoning_budget_message  string | null (null = the engine's default text;
+                                        "" = close the thinking block with no message)
+
+            Values survive later ``/admin/load`` swaps and the no-model state (they are
+            written into the holder's stored load kwargs). The whole patch is validated
+            before anything is mutated, so a 400 never leaves a partial update.
+            """
+            # do_POST decodes any JSON value — a null/array/scalar body must be a clean 400
+            # here, not a TypeError-turned-500 from the `in` checks below.
+            if not isinstance(req, dict):
+                return self._send_error(400, "request body must be a JSON object")
+            patch: dict = {}
+            if "enable_thinking" in req:
+                v = req["enable_thinking"]
+                if v is not None and not isinstance(v, bool):
+                    return self._send_error(400, "'enable_thinking' must be a boolean, or "
+                                                 "null to clear the override (the template's "
+                                                 "own default then applies)")
+                patch["enable_thinking"] = v
+            if "reasoning_budget" in req:
+                try:
+                    patch["reasoning_budget"] = _think_budget(req["reasoning_budget"])
+                except ValueError as e:
+                    return self._send_error(400, str(e))
+            if "reasoning_budget_message" in req:
+                v = req["reasoning_budget_message"]
+                if v is not None and not isinstance(v, str):
+                    return self._send_error(400, "'reasoning_budget_message' must be a "
+                                                 "string, or null for the engine's default "
+                                                 "text ('' closes the block with no message)")
+                patch["reasoning_budget_message"] = v
+            if isinstance(engine, EngineHolder):
+                return self._send_json(200, engine.configure(patch))
+            _apply_reasoning_config(engine, patch)     # bare-Engine servers (tests)
+            return self._send_json(200, _reasoning_config_of(engine))
 
         def _race(self, req: dict):
             """Same prompt, several decode strategies, streamed as SSE.
@@ -2046,6 +2230,10 @@ def make_handler(engine: Engine, api_key: str | None):
                         return self._send_error(
                             501, "this server was not started with hot-swap support")
                     return self._send_json(200, engine.unload())
+                if route == "/admin/config":
+                    # Reasoning knobs are read live per request, so this needs no model —
+                    # it also works in the no-model state (updates the stored load kwargs).
+                    return self._config(req)
                 if not self._require_ready():
                     return
                 if route in ("/v1/chat/completions", "/chat/completions"):
@@ -2182,6 +2370,24 @@ def make_handler(engine: Engine, api_key: str | None):
             # emit it — silently discarding model output is the worse failure.
             th = req.get("thinking")
             want_thinking = not (isinstance(th, dict) and th.get("type") == "disabled")
+            # Reasoning budget: thinking.budget_tokens (the Anthropic field, honored as a
+            # per-request override) > the server default; type "disabled" means no budget
+            # (thinking is off entirely); never applied to muse-format models.
+            try:
+                budget, explicit = engine.default_think_budget, False
+                if isinstance(th, dict):
+                    if th.get("type") == "disabled":
+                        budget = None
+                    elif th.get("budget_tokens") is not None:
+                        budget = _think_budget(th.get("budget_tokens"),
+                                               field="thinking.budget_tokens")
+                        explicit = True
+            except ValueError as e:
+                return self._send_json(400, A.error_body(str(e)))
+            if budget and not engine.is_muse:
+                params["think_budget"] = budget
+                params["budget_message"] = engine.think_budget_message
+                params["budget_explicit"] = explicit
             # tool schemas type the XML tool-call form, whose values are raw text
             schemas = schema_types(req.get("tools"))
             if req.get("stream"):
@@ -2190,7 +2396,9 @@ def make_handler(engine: Engine, api_key: str | None):
             body = A.build_message(res.text, model=model, input_tokens=len(prompt_ids),
                                    output_tokens=res.num_tokens,
                                    finish_reason=res.finish_reason, thinking=want_thinking,
-                                   schemas=schemas)
+                                   schemas=schemas,
+                                   in_thinking=self._prompt_opens_thinking(prompt_ids)
+                                   or None)
             body["x_mlx_dspark"] = engine.spec_info(res)   # non-standard; clients ignore it
             self._send_json(200, body)
 
@@ -2282,6 +2490,25 @@ def make_handler(engine: Engine, api_key: str | None):
             else:
                 _lp = req.get("logprobs")
                 params["logprobs"] = int(_lp) if _lp is not None else None
+            # reasoning budget (extension fields): request > server default; an explicit 0
+            # disables for this request; never applied to muse-format models (their channel
+            # format has no <think> pair to force-close).
+            try:
+                rb = req.get("reasoning_budget")
+                budget = _think_budget(rb) if rb is not None else engine.default_think_budget
+                msg = req.get("reasoning_budget_message")
+                if msg is not None and not isinstance(msg, str):
+                    raise ValueError("reasoning_budget_message must be a string")
+            except ValueError as e:
+                return self._send_error(400, str(e))
+            if budget and not engine.is_muse:
+                params["think_budget"] = budget
+                # "" is a real choice (close the block with no message) — only None defers
+                params["budget_message"] = (msg if msg is not None
+                                            else engine.think_budget_message)
+                # explicit budgets keep exact enforcement under --max-batch (serial path);
+                # the ambient server default never forfeits batching
+                params["budget_explicit"] = rb is not None
             model = req.get("model") or engine.model_id
             stream = bool(req.get("stream", False))
             n = max(1, min(int(req.get("n") or 1), 8))
@@ -2315,13 +2542,18 @@ def make_handler(engine: Engine, api_key: str | None):
                 "total_tokens": len(prompt_ids) + gen_tokens,
             }
             choices = []
+            # A template that PREFILLS the thinking opener (Qwen3-2507/qwen3_5) starts the
+            # output inside the block — split_thinking needs the closer hint or a thinking
+            # block truncated by max_tokens (no closer ever emitted) misreads as all-answer
+            # and the chain of thought leaks into content. Streaming has always passed this.
+            in_think = (self._prompt_opens_thinking(prompt_ids) or None) if chat else None
             for i, res in enumerate(res_list):
                 if chat:
                     # split reasoning out of the text (Qwen `<think>`, Gemma thought channel,
                     # muse `to=self` analysis) so it rides in `reasoning_content` instead of
                     # leaking into content — and so tool calls parse from the answer, not the
                     # reasoning. split_thinking auto-detects the format; no reasoning -> ("", text).
-                    reasoning, content = A.split_thinking(res.text)
+                    reasoning, content = A.split_thinking(res.text, in_thinking=in_think)
                     finish, tool_calls = res.finish_reason, None
                     if want_tools:
                         parsed, cleaned = parse_tool_calls(content, schema_types(req.get("tools")))

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -469,6 +469,34 @@ def test_split_thinking_self_opened_and_prefilled_and_absent():
     assert A.split_thinking("<think>cut off") == ("cut off", "")
 
 
+def test_split_thinking_in_thinking_hint_covers_the_truncated_prefill():
+    # terminated: same split with or without the hint
+    assert A.split_thinking("reasoning</think>\n\nanswer",
+                            in_thinking="</think>") == ("reasoning", "answer")
+    # TRUNCATED (max_tokens cut the thinking; no opener, no closer): only the hint can
+    # tell — with it the text is all reasoning...
+    cut = "half a thought, cut by max_tokens"
+    assert A.split_thinking(cut, in_thinking="</think>") == (cut, "")
+    # ...without it the old undetectable-case behavior stands (all-answer)
+    assert A.split_thinking(cut) == ("", cut)
+    # the hint carries the family-correct closer (Gemma-4)
+    assert A.split_thinking("weighing\n<channel|>Fixed.",
+                            in_thinking="<channel|>") == ("weighing\n", "Fixed.")
+    # no hint (None/""): every existing path is untouched
+    assert A.split_thinking("<think>r</think>\na", in_thinking=None) == ("r", "a")
+
+
+def test_build_message_in_thinking_truncated_becomes_a_thinking_block():
+    msg = A.build_message("half a thought", model="m", input_tokens=1, output_tokens=2,
+                          finish_reason="length", in_thinking="</think>")
+    assert msg["content"][0] == {"type": "thinking", "thinking": "half a thought",
+                                 "signature": "mlx-dspark"}
+    # thinking disabled discards it and still returns a (empty-text) block
+    msg = A.build_message("half a thought", model="m", input_tokens=1, output_tokens=2,
+                          finish_reason="length", thinking=False, in_thinking="</think>")
+    assert msg["content"] == [{"type": "text", "text": ""}]
+
+
 def test_prompt_opens_thinking_returns_the_matching_closer():
     assert A.prompt_opens_thinking("<|im_start|>assistant\n<think>\n") == "</think>"
     assert A.prompt_opens_thinking("<|im_start|>assistant\n") is None
@@ -605,6 +633,8 @@ class _FakeEngine:
     sampling_defaults = {}
     default_max_tokens = 2048
     max_tokens_cap = 32768
+    default_think_budget = None   # mirrors Engine (server default reasoning budget)
+    think_budget_message = None
     cap_controller = None
     context_window = None
     is_muse = False           # mirrors Engine.is_muse (muse_glimmer channel parsing off)
@@ -616,10 +646,13 @@ class _FakeEngine:
 
     def generate(self, prompt_ids, *, max_tokens, temperature, top_p=1.0, top_k=0,
                  presence_penalty=0.0, frequency_penalty=0.0, logprobs=None,
-                 stop=None, seed=None, on_text=None):
+                 stop=None, seed=None, think_budget=None, budget_message=None,
+                 budget_explicit=False, on_text=None):
         self.calls.append({"prompt_ids": prompt_ids, "max_tokens": max_tokens,
                                "temperature": temperature, "top_p": top_p, "top_k": top_k,
-                               "stop": stop, "seed": seed})
+                               "stop": stop, "seed": seed, "think_budget": think_budget,
+                               "budget_message": budget_message,
+                               "budget_explicit": budget_explicit})
         text = self.response_text
         if on_text:
             for i in range(0, len(text), 5):
@@ -694,6 +727,59 @@ def test_messages_accepts_the_beta_query_claude_code_sends(api):
     _, base = api
     r = _post(base, "/v1/messages?beta=true", {"max_tokens": 10, "messages": USER})
     assert r["type"] == "message"
+
+
+def test_messages_truncated_prefilled_thinking_becomes_a_thinking_block(api):
+    # non-streaming /v1/messages counterpart of the OpenAI-side fix: a prefilled opener
+    # (prompt tail ends with <think>) + max_tokens truncation must yield a thinking block,
+    # not assistant prose carrying the chain of thought
+    eng, base = api
+    eng.response_text = "half a thought"
+    r = _post(base, "/v1/messages",
+              {"max_tokens": 10, "messages": [{"role": "user", "content": "hi\n<think>"}]})
+    assert r["content"][0]["type"] == "thinking"
+    assert r["content"][0]["thinking"] == "half a thought"
+    assert all(b.get("text") != "half a thought" for b in r["content"])
+
+
+def test_messages_thinking_budget_tokens_is_honored(api):
+    eng, base = api
+    _post(base, "/v1/messages", {"max_tokens": 100, "messages": USER,
+                                 "thinking": {"type": "enabled", "budget_tokens": 2048}})
+    assert eng.calls[-1]["think_budget"] == 2048
+    assert eng.calls[-1]["budget_explicit"] is True
+    # streaming shares the same params
+    _post(base, "/v1/messages", {"max_tokens": 100, "messages": USER, "stream": True,
+                                 "thinking": {"type": "enabled", "budget_tokens": 512}},
+          raw=True)
+    assert eng.calls[-1]["think_budget"] == 512
+
+
+def test_messages_budget_default_and_disabled_precedence(api):
+    eng, base = api
+    _post(base, "/v1/messages", {"max_tokens": 100, "messages": USER})
+    assert eng.calls[-1]["think_budget"] is None       # no default configured
+    eng.default_think_budget = 8192
+    _post(base, "/v1/messages", {"max_tokens": 100, "messages": USER})
+    assert eng.calls[-1]["think_budget"] == 8192       # server default applies
+    assert eng.calls[-1]["budget_explicit"] is False   # ambient: batching keeps working
+    _post(base, "/v1/messages", {"max_tokens": 100, "messages": USER,
+                                 "thinking": {"type": "disabled"}})
+    assert eng.calls[-1]["think_budget"] is None       # thinking off: no budget either
+    eng.is_muse = True
+    _post(base, "/v1/messages", {"max_tokens": 100, "messages": USER,
+                                 "thinking": {"type": "enabled", "budget_tokens": 512}})
+    assert eng.calls[-1]["think_budget"] is None       # never on muse-format models
+
+
+def test_messages_malformed_budget_tokens_is_400(api):
+    _, base = api
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(base, "/v1/messages", {"max_tokens": 100, "messages": USER,
+                                     "thinking": {"type": "enabled",
+                                                  "budget_tokens": "lots"}})
+    assert e.value.code == 400
+    assert "budget_tokens" in json.loads(e.value.read())["error"]["message"]
 
 
 def test_messages_streaming_event_sequence(api):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,61 @@
+"""CLI-boundary tests: the reasoning budget is opt-in (default off) on both commands.
+
+The engine-layer tests all set ``default_think_budget`` themselves, so they would keep
+passing if an argparse default silently regressed to a non-zero value — these pin the
+actual defaults. Both commands import their collaborators inside the function body, so the
+fakes are patched onto the SOURCE modules; the call-time ``from .x import y`` then binds
+them.
+"""
+
+import importlib
+from types import SimpleNamespace
+
+import mlx_dspark.generate as generate
+import mlx_dspark.load as load
+import mlx_dspark.server as server
+from mlx_dspark import cli
+
+# `mlx_dspark.calibrate` the attribute is the calibrate() FUNCTION (re-exported by the
+# package __init__), which shadows the submodule — go through importlib for the module.
+calibrate = importlib.import_module("mlx_dspark.calibrate")
+
+
+def _serve_load_kwargs(monkeypatch, argv):
+    captured = {}
+
+    def fake_run_server(holder, **kw):
+        captured["holder"] = holder
+
+    monkeypatch.setattr(server, "run_server", fake_run_server)
+    cli.cmd_serve(["--no-model", *argv])
+    return captured["holder"]._load_kwargs
+
+
+def test_serve_reasoning_budget_is_opt_in(monkeypatch):
+    assert _serve_load_kwargs(monkeypatch, [])["default_think_budget"] is None
+    assert _serve_load_kwargs(
+        monkeypatch, ["--reasoning-budget", "8192"])["default_think_budget"] == 8192
+    assert _serve_load_kwargs(
+        monkeypatch, ["--reasoning-budget", "0"])["default_think_budget"] is None
+
+
+def _generate_think_budget(monkeypatch, argv):
+    captured = {}
+
+    def fake_greedy(target, tok, prompt, **kw):
+        captured.update(kw)
+        return SimpleNamespace(text="ok", num_tokens=3, seconds=0.1, tokens_per_sec=30.0)
+
+    monkeypatch.setattr(load, "resolve_mode",
+                        lambda *a, **k: ("baseline", "fake/target", None))
+    monkeypatch.setattr(load, "load_target", lambda *a, **k: (object(), object()))
+    monkeypatch.setattr(calibrate, "apply_small_m", lambda *a, **k: None)
+    monkeypatch.setattr(calibrate, "apply_wide_gemm", lambda *a, **k: None)
+    monkeypatch.setattr(generate, "greedy_generate", fake_greedy)
+    cli.cmd_generate(["--mode", "baseline", "--model", "fake/target", "--no-stream", *argv])
+    return captured["think_budget"]
+
+
+def test_generate_reasoning_budget_is_opt_in(monkeypatch):
+    assert _generate_think_budget(monkeypatch, []) is None
+    assert _generate_think_budget(monkeypatch, ["--reasoning-budget", "8192"]) == 8192

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -39,6 +39,8 @@ class _FakeEngine:
     sampling_defaults = {}
     default_max_tokens = 2048
     max_tokens_cap = 32768
+    default_think_budget = None   # mirrors Engine (server default reasoning budget)
+    think_budget_message = None
     cap_controller = None
     is_muse = False           # mirrors Engine.is_muse (muse_glimmer channel parsing off)
 
@@ -46,15 +48,21 @@ class _FakeEngine:
         self.tokenizer = _FakeTok()
         self.calls = []
         self.response_text = "Hello world from mlx dspark"
+        # instance-level: /admin/config mutates it, and a class-level dict would leak
+        # one test's mutation into the next
+        self.template_defaults = {}
 
     def generate(self, prompt_ids, *, max_tokens, temperature, top_p=1.0, top_k=0,
                  presence_penalty=0.0, frequency_penalty=0.0, logprobs=None,
-                 stop, seed, on_text=None):
+                 stop, seed, think_budget=None, budget_message=None, budget_explicit=False,
+                 on_text=None):
         self.calls.append({"prompt_ids": prompt_ids, "max_tokens": max_tokens,
                                "temperature": temperature, "top_p": top_p, "top_k": top_k,
                                "presence_penalty": presence_penalty,
                                "frequency_penalty": frequency_penalty, "logprobs": logprobs,
-                               "stop": stop, "seed": seed})
+                               "stop": stop, "seed": seed, "think_budget": think_budget,
+                               "budget_message": budget_message,
+                               "budget_explicit": budget_explicit})
         text = self.response_text
         if on_text:
             for w in text.split(" "):
@@ -547,6 +555,306 @@ def test_supports_reasoning_effort_tracks_the_template():
     tok = _ThinkTok()
     tok.chat_template = "{% if reasoning_effort == 'low' %}brief{% endif %}"
     assert _probe_engine(tok).supports_reasoning_effort is True
+
+
+def test_nonstream_chat_truncated_prefilled_thinking_stays_reasoning(server):
+    # A template that PREFILLS <think> (the prompt tail ends with the opener) plus a
+    # generation truncated by max_tokens leaves neither opener nor closer in the text.
+    # The non-streaming split must still classify it as reasoning, not leak it as content.
+    eng, base = server
+    eng.response_text = "half a thought, cut by max_tokens"
+    body = {"messages": [{"role": "user", "content": "hi\n<think>"}]}
+    msg = _post(base, "/v1/chat/completions", body)["choices"][0]["message"]
+    assert msg["reasoning_content"] == "half a thought, cut by max_tokens"
+    assert not msg["content"]
+    # when the closer DID arrive, the split is what it always was
+    eng.response_text = "done thinking</think>\nThe answer."
+    msg = _post(base, "/v1/chat/completions", body)["choices"][0]["message"]
+    assert msg["reasoning_content"] == "done thinking"
+    assert msg["content"] == "The answer."
+    # and a prompt that does NOT end in an opener keeps the old all-answer reading
+    eng.response_text = "half a thought, cut by max_tokens"
+    msg = _post(base, "/v1/chat/completions",
+                {"messages": [{"role": "user", "content": "hi"}]})["choices"][0]["message"]
+    assert msg["content"] == "half a thought, cut by max_tokens"
+    assert "reasoning_content" not in msg
+
+
+def test_think_budget_normalization():
+    assert S._think_budget(512) == 512
+    assert S._think_budget(0) is None                    # explicit 0 = disabled
+    for bad in (True, False, "lots", 1.5, -1, None):
+        with pytest.raises(ValueError):
+            S._think_budget(bad)
+
+
+def test_reasoning_budget_field_reaches_generate(server):
+    eng, base = server
+    _post(base, "/v1/chat/completions",
+          {"messages": [{"role": "user", "content": "hi"}], "reasoning_budget": 512,
+           "reasoning_budget_message": "Wrap it up."})
+    assert eng.calls[-1]["think_budget"] == 512
+    assert eng.calls[-1]["budget_message"] == "Wrap it up."
+    assert eng.calls[-1]["budget_explicit"] is True
+    # "" is preserved (close the block with no message), not swapped for the default
+    eng.think_budget_message = "Server default."
+    _post(base, "/v1/chat/completions",
+          {"messages": [{"role": "user", "content": "hi"}], "reasoning_budget": 512,
+           "reasoning_budget_message": ""})
+    assert eng.calls[-1]["budget_message"] == ""
+    # streaming goes through the same params dict
+    _post(base, "/v1/chat/completions",
+          {"messages": [{"role": "user", "content": "hi"}], "reasoning_budget": 256,
+           "stream": True}, stream=True)
+    assert eng.calls[-1]["think_budget"] == 256
+
+
+def test_reasoning_budget_engine_default_and_zero_disables(server):
+    eng, base = server
+    body = {"messages": [{"role": "user", "content": "hi"}]}
+    _post(base, "/v1/chat/completions", body)
+    assert eng.calls[-1]["think_budget"] is None         # no default configured
+    eng.default_think_budget = 8192
+    eng.think_budget_message = "Answer."
+    _post(base, "/v1/chat/completions", body)
+    assert eng.calls[-1]["think_budget"] == 8192         # server default applies
+    assert eng.calls[-1]["budget_message"] == "Answer."
+    assert eng.calls[-1]["budget_explicit"] is False     # ambient: batching keeps working
+    _post(base, "/v1/chat/completions", {**body, "reasoning_budget": 0})
+    assert eng.calls[-1]["think_budget"] is None         # explicit 0 overrides the default
+
+
+def test_reasoning_budget_invalid_is_400(server):
+    _eng, base = server
+    for bad in (True, "lots", 1.5, -1):
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _post(base, "/v1/chat/completions",
+                  {"messages": [{"role": "user", "content": "hi"}], "reasoning_budget": bad})
+        assert e.value.code == 400
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(base, "/v1/chat/completions",
+              {"messages": [{"role": "user", "content": "hi"}], "reasoning_budget": 5,
+               "reasoning_budget_message": 7})
+    assert e.value.code == 400
+
+
+def test_reasoning_budget_not_passed_on_muse(server):
+    eng, base = server
+    eng.is_muse = True
+    eng.default_think_budget = 8192
+    _post(base, "/v1/chat/completions",
+          {"messages": [{"role": "user", "content": "hi"}], "reasoning_budget": 512})
+    assert eng.calls[-1]["think_budget"] is None
+
+
+def test_health_reports_reasoning_budget(server):
+    eng, base = server
+    assert _get(base, "/health")["reasoning_budget"] is None
+    eng.default_think_budget = 4096
+    assert _get(base, "/health")["reasoning_budget"] == 4096
+
+
+def test_health_supports_reasoning_budget_gates_on_muse(server):
+    # A per-request budget control must gate on this, not admin_config: the muse request
+    # path deliberately skips think_budget, so the control would do nothing there.
+    eng, base = server
+    assert _get(base, "/health")["supports_reasoning_budget"] is True
+    eng.is_muse = True
+    assert _get(base, "/health")["supports_reasoning_budget"] is False
+
+
+def test_health_reports_reasoning_budget_with_no_model_loaded():
+    holder = S.EngineHolder(None, {"default_think_budget": 4096}, max_batch=1)
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), S.make_handler(holder, api_key=None))
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        h = _get(f"http://127.0.0.1:{httpd.server_address[1]}", "/health")
+        assert h["status"] == "no_model" and h["reasoning_budget"] == 4096
+        # no model = no answer about what the model supports; the key stays absent
+        assert "supports_reasoning_budget" not in h
+    finally:
+        httpd.shutdown()
+
+
+def test_engine_load_rejects_bad_budget_knobs():
+    with pytest.raises(ValueError):
+        S.Engine.load(model="whatever", default_think_budget=-5)
+    with pytest.raises(ValueError):
+        S.Engine.load(model="whatever", think_budget_message=7)
+
+
+def test_admin_config_mutates_live_engine_no_reload(server):
+    eng, base = server
+    r = _post(base, "/admin/config", {"enable_thinking": False, "reasoning_budget": 512,
+                                      "reasoning_budget_message": "Hurry."})
+    assert r == {"enable_thinking": False, "reasoning_budget": 512,
+                 "reasoning_budget_message": "Hurry."}
+    assert eng.default_think_budget == 512
+    assert eng.think_budget_message == "Hurry."
+    assert eng.template_defaults["enable_thinking"] is False
+    # effective immediately: the very next request runs with the new default
+    _post(base, "/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}]})
+    assert eng.calls[-1]["think_budget"] == 512
+    assert eng.calls[-1]["budget_message"] == "Hurry."
+
+
+def test_admin_config_explicit_true_null_zero_and_empty(server):
+    eng, base = server
+    # explicit ON is stored as True — it must WIN over a template whose default is off,
+    # not merely clear the override
+    _post(base, "/admin/config", {"enable_thinking": True})
+    assert eng.template_defaults["enable_thinking"] is True
+    _post(base, "/admin/config", {"enable_thinking": None})
+    assert "enable_thinking" not in eng.template_defaults      # null clears the override
+    eng.default_think_budget = 8192
+    _post(base, "/admin/config", {"reasoning_budget": 0})
+    assert eng.default_think_budget is None                     # 0 disables
+    _post(base, "/admin/config", {"reasoning_budget_message": ""})
+    assert eng.think_budget_message == ""                       # explicit empty preserved
+    _post(base, "/admin/config", {"reasoning_budget_message": None})
+    assert eng.think_budget_message is None                     # null = engine default
+
+
+def test_admin_config_validates_whole_patch_before_mutating(server):
+    eng, base = server
+    # a valid budget beside an invalid message must change NOTHING
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(base, "/admin/config", {"reasoning_budget": 512,
+                                      "reasoning_budget_message": 7})
+    assert e.value.code == 400
+    assert eng.default_think_budget is None
+    for body in ({"reasoning_budget": -1}, {"reasoning_budget": True},
+                 {"reasoning_budget": "x"}, {"enable_thinking": 3}):
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _post(base, "/admin/config", body)
+        assert e.value.code == 400
+
+
+def test_admin_config_rejects_non_object_bodies(server):
+    eng, base = server
+    # do_POST decodes any JSON value; each of these must be a clean 400 (not a 500 from
+    # the `in` membership checks) and must mutate nothing — including [] , which the `in`
+    # operator would otherwise wave through as an accidental read-back.
+    for body in (None, [], ["reasoning_budget"], "reasoning_budget", 5):
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _post(base, "/admin/config", body)
+        assert e.value.code == 400
+    assert eng.default_think_budget is None
+
+
+def test_admin_config_empty_body_reads_back(server):
+    eng, base = server
+    eng.default_think_budget = 4096
+    assert _post(base, "/admin/config", {}) == {
+        "enable_thinking": None, "reasoning_budget": 4096,
+        "reasoning_budget_message": None}
+
+
+def _serve_handler(target):
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), S.make_handler(target, api_key=None))
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"
+
+
+def test_admin_config_reaches_inner_engine_through_holder_and_batch_wrapper():
+    inner = _FakeEngine()
+    batch = object.__new__(S.BatchEngine)   # real class (isinstance + __getattr__), no threads
+    batch.engine = inner
+    holder = S.EngineHolder(batch, {"default_think_budget": 8192})
+    httpd, base = _serve_handler(holder)
+    try:
+        _post(base, "/admin/config", {"reasoning_budget": 256, "enable_thinking": True})
+        # the INNERMOST engine mutated — and no shadowing attrs on the delegating wrappers,
+        # which would permanently break their __getattr__ forwarding
+        assert inner.default_think_budget == 256
+        assert inner.template_defaults["enable_thinking"] is True
+        assert "default_think_budget" not in batch.__dict__
+        assert "default_think_budget" not in holder.__dict__
+        # and the stored load kwargs carry the values into any later swap
+        assert holder._load_kwargs["default_think_budget"] == 256
+        assert holder._load_kwargs["enable_thinking"] is True
+    finally:
+        httpd.shutdown()
+
+
+def test_admin_config_no_model_updates_kwargs():
+    holder = S.EngineHolder(None, {"default_think_budget": 8192})
+    httpd, base = _serve_handler(holder)
+    try:
+        r = _post(base, "/admin/config", {"reasoning_budget": 512,
+                                          "reasoning_budget_message": "Go.",
+                                          "enable_thinking": False})
+        assert r == {"enable_thinking": False, "reasoning_budget": 512,
+                     "reasoning_budget_message": "Go."}
+        assert holder._load_kwargs["default_think_budget"] == 512
+        assert holder._load_kwargs["think_budget_message"] == "Go."
+        assert holder._load_kwargs["enable_thinking"] is False
+        # /health (no-model branch) reflects the stored values + the capability flag
+        h = _get(base, "/health")
+        assert h["status"] == "no_model" and h["admin_config"] is True
+        assert h["reasoning_budget"] == 512
+        assert h["reasoning_budget_message"] == "Go."
+        assert h["enable_thinking"] is False
+    finally:
+        httpd.shutdown()
+
+
+def test_health_reports_thinking_and_message_keys(server):
+    eng, base = server
+    h = _get(base, "/health")
+    assert h["admin_config"] is True
+    assert h["enable_thinking"] is None and h["reasoning_budget_message"] is None
+    eng.template_defaults["enable_thinking"] = True
+    eng.think_budget_message = "Answer."
+    h = _get(base, "/health")
+    assert h["enable_thinking"] is True and h["reasoning_budget_message"] == "Answer."
+
+
+def test_direct_batch_engine_callers_get_explicit_budget_enforcement():
+    # a library caller passing think_budget without knowing about the scheduler hint must
+    # queue an EXPLICIT job (enforced via the serial path), never an ambient one that a
+    # concurrent batch could silently skip
+    be = object.__new__(S.BatchEngine)
+
+    class _CaptureQ:
+        def __init__(self):
+            self.jobs = []
+
+        def put(self, job):
+            self.jobs.append(job)
+            job.result = "done"
+            job.done.set()
+
+    be._q = _CaptureQ()
+    be.generate([1, 2], max_tokens=5, temperature=0.0, think_budget=512)
+    assert be._q.jobs[0].params["budget_explicit"] is True
+    assert not S.BatchEngine._batchable_greedy(be._q.jobs[0])
+
+
+def test_batch_routing_explicit_budget_serial_ambient_budget_batches():
+    from types import SimpleNamespace
+
+    ok = {"presence_penalty": 0, "frequency_penalty": 0, "logprobs": None,
+          "temperature": 0.0, "think_budget": None, "budget_explicit": False}
+    assert S.BatchEngine._batchable_greedy(SimpleNamespace(params=ok))
+    # an EXPLICITLY requested budget forfeits batching for exact enforcement...
+    assert not S.BatchEngine._batchable_greedy(
+        SimpleNamespace(params={**ok, "think_budget": 512, "budget_explicit": True}))
+    # ...but the ambient server default must NOT disable --max-batch across the board
+    assert S.BatchEngine._batchable_greedy(
+        SimpleNamespace(params={**ok, "think_budget": 8192}))
+    be = object.__new__(S.BatchEngine)
+    be.engine = SimpleNamespace(mode="dspark")
+    routed = []
+    be._run_serial = lambda j: routed.append("serial")
+    be._run_session = lambda jobs: routed.append("session")
+    be._run_batched = lambda jobs, key: routed.append("batched")
+    jobs = [SimpleNamespace(params={**ok, "top_p": 1.0, "top_k": 0,
+                                    "think_budget": 512, "budget_explicit": True}),
+            SimpleNamespace(params={**ok, "top_p": 1.0, "top_k": 0, "think_budget": 8192}),
+            SimpleNamespace(params={**ok, "top_p": 1.0, "top_k": 0, "think_budget": 8192})]
+    be._run(jobs)
+    assert routed == ["serial", "session"]
 
 
 def test_race_reasoning_effort_param_validated_and_echoed(server):

--- a/tests/test_think_budget.py
+++ b/tests/test_think_budget.py
@@ -1,0 +1,470 @@
+"""Reasoning-budget tests: the ThinkBudget tracker (detection, forced-close ids) and the
+forced-injection mechanics inside every generation loop, driven by scripted fake targets and
+a fake DSpark/DFlash drafter. No weights required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from mlx_dspark.generate import (
+    DEFAULT_BUDGET_MESSAGE,
+    ThinkBudget,
+    dflash_generate,
+    greedy_generate,
+    speculative_generate,
+)
+from mlx_dspark.lookup import lookup_generate
+
+V = 512   # fake vocab: ids are character code points (ASCII only)
+
+FORCED_TEXT = "\n\n" + DEFAULT_BUDGET_MESSAGE + "\n</think>\n\n"
+
+
+class _Tok:
+    """1 id per character; convert_tokens_to_ids knows nothing (or one closer id)."""
+
+    unk_token_id = 0
+    eos_token_id = 1
+
+    def __init__(self, closer_id=None):
+        self.closer_id = closer_id
+
+    def encode(self, text, add_special_tokens=True):
+        return [ord(c) for c in text]
+
+    def decode(self, ids):
+        return "".join(chr(int(i)) for i in ids)
+
+    def convert_tokens_to_ids(self, t):
+        if self.closer_id is not None and t == "</think>":
+            return self.closer_id
+        return self.unk_token_id
+
+
+def _ids(text):
+    return [ord(c) for c in text]
+
+
+def _feed(tb, text, per=1):
+    """Feed `text` to the tracker `per` tokens at a time; returns (out_ids, fired_at) where
+    fired_at is the out_ids length at the first True from note(), or None."""
+    out = []
+    for i in range(0, len(text), per):
+        out += _ids(text[i:i + per])
+        if tb.note(out):
+            return out, len(out)
+    return out, None
+
+
+# --------------------------------------------------------------------- ThinkBudget unit
+
+
+def test_fires_at_budget_and_builds_the_forced_close():
+    tb = ThinkBudget(_Tok(), budget=10)
+    out, fired_at = _feed(tb, "<think>" + "x" * 30)
+    # opener completes at 7 tokens; 10 thinking tokens later -> fires at 17
+    assert fired_at == 17
+    forced = tb.take_forced_ids(remaining=1000)
+    assert _Tok().decode(forced) == FORCED_TEXT
+    assert tb.fired
+    assert not tb.note(out)                       # once-only: disarmed after firing
+
+
+def test_opener_straddling_note_calls_is_still_seen():
+    tb = ThinkBudget(_Tok(), budget=5)
+    out = _ids("<th")
+    assert not tb.note(out)
+    out += _ids("ink>")
+    assert not tb.note(out)
+    out += _ids("abcde")
+    assert tb.note(out)                            # 5 tokens past the (straddled) opener
+
+
+def test_note_is_idempotent():
+    tb = ThinkBudget(_Tok(), budget=3)
+    out = _ids("<think>")
+    assert not tb.note(out) and not tb.note(out)   # same out_ids -> same answer, twice
+    out = out + _ids("abc")
+    assert tb.note(out) and tb.note(out)
+
+
+def test_holds_fire_while_the_tail_might_be_the_closer():
+    # budget exceeded exactly while the model is mid-`</think>`: wait one round rather
+    # than injecting a second close into a block that is closing itself
+    tb = ThinkBudget(_Tok(), budget=3)
+    out = _ids("<think>abc</thi")
+    for n in range(8, len(out) + 1):
+        assert not tb.note(out[:n])
+    assert tb.note(out + _ids("s is fine"))        # a false alarm: it WAS thinking text
+    tb2 = ThinkBudget(_Tok(), budget=3)
+    out2 = _ids("<think>abc</thi")
+    assert not tb2.note(out2)
+    assert not tb2.note(out2 + _ids("nk>done"))    # it WAS the closer: disarmed
+
+
+def test_prefilled_opener_counts_from_token_zero():
+    # Qwen3-2507-style: the template ends the prompt with the opener, so the output never
+    # contains one — auto-detected from the prompt tail, counting starts at token 0.
+    tb = ThinkBudget(_Tok(), budget=4, prompt_tail_ids=_ids("Q: hi\n<think>"))
+    _out, fired_at = _feed(tb, "yyyyyyyy")
+    assert fired_at == 4
+
+
+def test_gemma_pair_discovers_its_own_closer():
+    tb = ThinkBudget(_Tok(), budget=3)
+    _out, fired_at = _feed(tb, "<|channel>thought\n" + "z" * 10)
+    assert fired_at is not None
+    assert tb.close_marker == "<channel|>"
+    forced = tb.take_forced_ids(remaining=1000)
+    assert _Tok().decode(forced).endswith("<channel|>\n\n")
+
+
+def test_model_closing_its_own_block_disarms():
+    tb = ThinkBudget(_Tok(), budget=5)
+    _out, fired_at = _feed(tb, "<think>ab</think>the answer, at length" + "!" * 30)
+    assert fired_at is None and not tb.fired
+
+
+def test_plain_answer_without_thinking_never_fires():
+    tb = ThinkBudget(_Tok(), budget=2)
+    _out, fired_at = _feed(tb, "just prose, no thinking block here at all")
+    assert fired_at is None
+
+
+def test_eos_ids_are_filtered_from_the_forced_close():
+    eos = {ord("n")}
+    tb = ThinkBudget(_Tok(), budget=2, eos_ids=eos)
+    _feed(tb, "<think>xxxx")
+    forced = tb.take_forced_ids(remaining=1000)
+    assert not set(forced) & eos
+    assert _Tok().decode(forced) == FORCED_TEXT.replace("n", "")
+
+
+def test_insufficient_remaining_skips_injection_without_arming():
+    tb = ThinkBudget(_Tok(), budget=2)
+    _feed(tb, "<think>xxxx")
+    assert tb.take_forced_ids(remaining=3) == []   # never truncate the closer
+    assert not tb.fired
+    assert tb.take_forced_ids(remaining=1000)      # a later, roomier call still fires
+
+
+def test_non_positive_budget_is_rejected():
+    import pytest
+
+    for bad in (0, -1):
+        with pytest.raises(ValueError):
+            ThinkBudget(_Tok(), budget=bad)
+
+
+def test_empty_message_closes_the_block_with_no_message():
+    tb = ThinkBudget(_Tok(), budget=2, message="")
+    _feed(tb, "<think>xxxx")
+    forced = tb.take_forced_ids(remaining=1000)
+    assert _Tok().decode(forced) == "\n</think>\n\n"
+
+
+def test_custom_message_and_single_token_closer():
+    tb = ThinkBudget(_Tok(closer_id=400), budget=2, message="Stop.")
+    _feed(tb, "<think>xxxx")
+    forced = tb.take_forced_ids(remaining=1000)
+    assert forced.count(400) == 1                  # </think> resolved as ONE special token
+    assert _ids("</think>")[0] not in forced or forced[forced.index(400) - 1] != ord("k")
+    text = "".join(chr(i) for i in forced if i != 400)
+    assert text == "\n\nStop.\n" + "\n\n"
+
+
+# ------------------------------------------------------------------ scripted fake target
+
+
+class _ScriptTgt:
+    """Greedy target that 'wants' to emit ``full_text[len(prompt):]``: the argmax after
+    consuming T tokens is full_text[T] (pad past the end; pad is never eos). Records every
+    token fed through the cache plus verify/rollback events, so tests can assert exactly
+    what the KV cache saw."""
+
+    def __init__(self, full_text, pad="A"):
+        self.full = _ids(full_text)
+        self.pad = ord(pad)
+        self.consumed = []       # the cache contents, in order
+        self.events = []         # ("verify", width) / ("rollback", n_rejected)
+
+    def make_cache(self):
+        return []
+
+    def reset_spec(self):
+        pass
+
+    def _pred(self, t):
+        return self.full[t] if t < len(self.full) else self.pad
+
+    def _logits(self, preds):
+        rows = []
+        for p in preds:
+            r = [0.0] * V
+            r[p] = 10.0
+            rows.append(r)
+        return mx.array([rows])
+
+    def _consume(self, ids):
+        toks = [int(x) for x in ids[0].tolist()]
+        preds = []
+        for t in toks:
+            self.consumed.append(t)
+            preds.append(self._pred(len(self.consumed)))
+        return self._logits(preds)
+
+    def prefill(self, ids, cache, tap=None, want_logits=True, head_last_row=True):
+        logits = self._consume(ids)
+        fused = mx.zeros((1, logits.shape[1], 4)) if tap is not None else None
+        return (logits[:, -1:, :] if want_logits else None), fused
+
+    def plain(self, ids, cache):
+        return self._consume(ids)
+
+    def verify(self, ids, cache, tap):
+        self.events.append(("verify", int(ids.shape[1])))
+        logits = self._consume(ids)
+        fused = mx.zeros((1, logits.shape[1], 4)) if tap is not None else None
+        return logits, fused
+
+    def rollback(self, cache, n_rejected, accepted):
+        self.events.append(("rollback", int(n_rejected)))
+        if n_rejected:
+            del self.consumed[-n_rejected:]
+
+
+PROMPT = "PQ"
+THINK_FOREVER = PROMPT + "<think>" + "x" * 200     # opens a block and never closes it
+
+
+# --------------------------------------------------------------- greedy_generate loops
+
+
+def test_greedy_pipelined_injects_and_continues():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    res = greedy_generate(tgt, _Tok(), prompt_ids=_ids(PROMPT), max_new_tokens=70,
+                          think_budget=10)
+    # opener = 7 tokens, budget 10 -> injection right after committed token 17
+    assert res.budget_forced
+    assert res.text.startswith("<think>" + "x" * 10 + FORCED_TEXT)
+    # the cache saw the forced tokens, contiguously, right where the text has them
+    assert FORCED_TEXT in _Tok().decode(tgt.consumed)
+    assert res.finish_reason == "length" and res.num_tokens == 70
+    # accounting: one injection == one forward that committed len(FORCED_TEXT) tokens,
+    # recorded chronologically — 17 plain rounds, then the injection, then plain again
+    assert res.target_forwards == res.num_rounds == 70 - len(FORCED_TEXT) + 1
+    assert res.accept_lengths[17] == len(FORCED_TEXT)
+    assert set(res.accept_lengths[:17]) == {1} and set(res.accept_lengths[18:]) == {1}
+
+
+def test_greedy_sequential_branch_injects_with_aligned_logprobs():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    res = greedy_generate(tgt, _Tok(), prompt_ids=_ids(PROMPT), max_new_tokens=60,
+                          think_budget=10, logprobs=0)
+    assert res.budget_forced and FORCED_TEXT in res.text
+    assert len(res.logprobs) == res.num_tokens == 60
+    assert [e["token_id"] for e in res.logprobs] == res.token_ids
+
+
+def test_greedy_injection_at_the_exact_remaining_boundary_terminates_cleanly():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    cap = 17 + len(FORCED_TEXT)          # fires at 17; forced close exactly fills the rest
+    res = greedy_generate(tgt, _Tok(), prompt_ids=_ids(PROMPT), max_new_tokens=cap,
+                          think_budget=10)
+    assert res.budget_forced and res.num_tokens == cap
+    assert res.finish_reason == "length"
+    assert res.text.endswith("</think>\n\n")
+    assert len(tgt.consumed) == len(PROMPT) + cap    # not one token generated past the cap
+
+
+def test_greedy_one_token_short_of_the_close_skips_injection():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    cap = 17 + len(FORCED_TEXT) - 1
+    res = greedy_generate(tgt, _Tok(), prompt_ids=_ids(PROMPT), max_new_tokens=cap,
+                          think_budget=10)
+    assert not res.budget_forced and FORCED_TEXT not in res.text
+    assert res.finish_reason == "length" and res.num_tokens == cap
+
+
+def test_greedy_stop_string_inside_the_forced_text_stops_generation():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    res = greedy_generate(tgt, _Tok(), prompt_ids=_ids(PROMPT), max_new_tokens=200,
+                          think_budget=10, stop=["answer now"])
+    assert res.budget_forced
+    assert res.finish_reason == "stop" and "answer now" not in res.text
+    assert res.num_tokens == 17 + len(FORCED_TEXT)   # committed the close, then stopped
+
+
+def test_greedy_prefilled_opener_counts_from_the_first_generated_token():
+    prompt = "hi\n<think>"
+    tgt = _ScriptTgt(prompt + "x" * 200)
+    res = greedy_generate(tgt, _Tok(), prompt_ids=_ids(prompt), max_new_tokens=70,
+                          think_budget=10)
+    assert res.budget_forced
+    assert res.text.startswith("x" * 10 + FORCED_TEXT)
+
+
+def test_greedy_without_budget_is_untouched():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    res = greedy_generate(tgt, _Tok(), prompt_ids=_ids(PROMPT), max_new_tokens=30)
+    assert not res.budget_forced and res.text == "<think>" + "x" * 23
+    assert res.target_forwards == 30 and res.accept_lengths == [1] * 30
+
+
+# --------------------------------------------------------------- lookup_generate loop
+
+
+def test_lookup_injects_through_one_forced_verify_with_zero_rollback():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    res = lookup_generate(tgt, _Tok(), prompt_ids=_ids(PROMPT), max_new_tokens=90,
+                          think_budget=10)
+    assert res.budget_forced and FORCED_TEXT in res.text
+    # the injection is one verify of exactly [pending] + forced[:-1] rows...
+    w = len(FORCED_TEXT)
+    idx = tgt.events.index(("verify", w))
+    # ...committed unconditionally: the very next rollback rejects nothing
+    nxt = next(e for e in tgt.events[idx + 1:] if e[0] == "rollback")
+    assert nxt == ("rollback", 0)
+    assert FORCED_TEXT in _Tok().decode(tgt.consumed)
+
+
+# ------------------------------------------------------- speculative_generate (DSpark)
+
+
+class _CtxCache:
+    def __init__(self):
+        self.k = mx.zeros((1,))
+        self.offset = 0
+
+
+class _SpecDrafter:
+    """Drafts a constant guess token; records every update_context (offset, rows) so the
+    ctx-alignment invariant can be checked across an injection."""
+
+    max_draft = 3
+    confidence_head = None
+
+    def __init__(self, guess="x"):
+        self.config = SimpleNamespace(target_layer_ids=[0], mask_token_id=0,
+                                      has_own_lm_head=True, has_own_embed=True)
+        self.guess = ord(guess)
+        self.ctx_updates = []      # (ctx_offset, n_rows)
+
+    def make_ctx_cache(self):
+        return [_CtxCache()]
+
+    def draft_width(self, cap):
+        return cap
+
+    def embed(self, block):
+        return mx.zeros((1, int(block.shape[1]), 4))
+
+    def backbone(self, noise, n_cached, ctx_caches):
+        return noise
+
+    def head_slice(self, hidden, cap):
+        return hidden[:, :cap]
+
+    def compute_logits(self, hidden):
+        L = int(hidden.shape[1])
+        rows = []
+        for _ in range(L):
+            r = [0.0] * V
+            r[self.guess] = 10.0
+            rows.append(r)
+        return mx.array([rows])
+
+    def sample_block(self, base_logits, first_prev_token=None):
+        return mx.argmax(base_logits, axis=-1)
+
+    def update_context(self, fused, ctx_offset=0, ctx_caches=None):
+        self.ctx_updates.append((int(ctx_offset), int(fused.shape[1])))
+
+
+def test_speculative_injection_keeps_drafter_ctx_offsets_aligned():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    drafter = _SpecDrafter()
+    res = speculative_generate(tgt, _Tok(), drafter, prompt_ids=_ids(PROMPT),
+                               max_new_tokens=120, max_draft_tokens=2,
+                               lookup_drafts=False, think_budget=10)
+    assert res.budget_forced and FORCED_TEXT in res.text
+    # ctx rows must tile [0, n_cached) contiguously: every update starts exactly where the
+    # previous one ended — a dropped or double-fed injection breaks this immediately
+    pos = 0
+    for off, rows in drafter.ctx_updates:
+        assert off == pos, drafter.ctx_updates
+        pos += rows
+    # everything committed except the final pending token is in the drafter ctx
+    assert pos == len(PROMPT) + res.num_tokens - 1
+    # the injection round is visible as one forward committing the whole forced close
+    assert len(FORCED_TEXT) in res.accept_lengths
+    # and its verify was committed unconditionally (rollback 0 right after the wide verify)
+    idx = tgt.events.index(("verify", len(FORCED_TEXT)))
+    assert tgt.events[idx + 1] == ("rollback", 0)
+
+
+def test_speculative_without_budget_is_untouched():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    res = speculative_generate(tgt, _Tok(), _SpecDrafter(), prompt_ids=_ids(PROMPT),
+                               max_new_tokens=40, max_draft_tokens=2, lookup_drafts=False)
+    assert not res.budget_forced and FORCED_TEXT not in res.text
+
+
+# --------------------------------------------------------------- dflash_generate loop
+
+
+class _DFlashDrafter:
+    """Block-diffusion-shaped fake: callable, drafts a constant guess; records the width of
+    every pending_ctx it is handed (DFlash appends pending_ctx to its draft cache at the
+    NEXT call, so an injection must concatenate onto it, not replace it)."""
+
+    embed_tokens = object()      # non-None: skip bind()
+
+    def __init__(self, guess="x", block_size=4):
+        self.config = SimpleNamespace(target_layer_ids=[0], block_size=block_size,
+                                      mask_token_id=0)
+        self.guess = ord(guess)
+        self.ctx_widths = []
+
+    def make_cache(self):
+        return [SimpleNamespace(offset=0)]
+
+    def __call__(self, block, pending_ctx, dcache, logits_start=1):
+        self.ctx_widths.append(int(pending_ctx.shape[1]))
+        k = int(block.shape[1]) - logits_start
+        rows = []
+        for _ in range(k):
+            r = [0.0] * V
+            r[self.guess] = 10.0
+            rows.append(r)
+        return mx.array([rows])
+
+
+def test_dflash_injection_concatenates_onto_the_deferred_pending_ctx():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    drafter = _DFlashDrafter()
+    res = dflash_generate(tgt, _Tok(), drafter, prompt_ids=_ids(PROMPT),
+                          max_new_tokens=120, think_budget=10)
+    assert res.budget_forced and FORCED_TEXT in res.text
+    # the round after the injection must see the PREVIOUS round's rows plus the forced
+    # rows — a plain overwrite would show len(FORCED_TEXT) alone and lose committed ctx
+    w = len(FORCED_TEXT)
+    k = res.accept_lengths.index(w)                # the injection "round"
+    assert k > 0
+    expected = res.accept_lengths[k - 1] + w
+    assert expected in drafter.ctx_widths, (drafter.ctx_widths, res.accept_lengths)
+    # every committed token's ctx row reaches the drafter exactly once: widths tile the
+    # sequence [prompt .. last uncommitted pending)
+    assert sum(drafter.ctx_widths[:-1]) <= len(PROMPT) + res.num_tokens - 1
+    idx = tgt.events.index(("verify", w))
+    assert tgt.events[idx + 1] == ("rollback", 0)
+
+
+def test_dflash_without_budget_is_untouched():
+    tgt = _ScriptTgt(THINK_FOREVER)
+    res = dflash_generate(tgt, _Tok(), _DFlashDrafter(), prompt_ids=_ids(PROMPT),
+                          max_new_tokens=40)
+    assert not res.budget_forced and FORCED_TEXT not in res.text


### PR DESCRIPTION
Hi, thanks for creating mlx-dspark and apologies for the unsolicited PR, but I thought the project could benefit from a reasoning budget feature and wanted to contribute.

Qwen-3.8 27b has a tendency to [significantly overthink](https://simonwillison.net/2026/Aug/16/qwen-38-27b/), which undermines the speedup benefits that are gained from DSpark. Other local agents like LM Studio Bionic have a function for reasoning budget that forces the model to answer if they have exceeded a certain token limit. 

This PR introduces a reasoning budget feature both on the server and the Mac App level, and enables the budget threshold to be toggled on/off and set to whatever arbitrary limit the user wants. As a default, the value of 8192 is picked, as this matched LM Studio Bionic's default. The feature is behind an opt-in switch and off by default, so regular users will see no change without manually opting in.

This is different to the Race tab's 'max_tokens' or the Thinking checkbox, insofar as max_tokens cuts off the model's response mid-thought with no answer and Thinking checkbox is an all-or-nothing enable or disable thinking toggle. 

By contrast, the reasoning budget feature only caps tokens expended within thinking blocks. Once the budget is passed, the interruption message and the close of the thinking block is injected. This causes the model to exit thinking and produce an answer, unlike the Race tab's limit.

Also full disclosure, this PR was written with the assistance of Fable 5 and underwent several reviews from GPT 5.6 Sol on xhigh, so if this is an issue, please feel free to ignore the PR entirely. 

This PR note was handwritten and I'm happy to make any alterations that might be required in order for this to be successfully merged and to respect the existing structuring of your project.

Thanks for reading and for your consideration. 

Note: 3 pre-existing numerics failures (test_bonsai, test_dflash2 ×2) fail identically on unmodified main in my environment (mlx version drift) - unrelated to this change.

**Steps to test**
1. Patch this PR to your local branch and build the Mac App.
2. The Mac app must be run against the backend from the PR branch. MLXDSPARK_ENGINE_SOURCE=$PWD open -n apps/MacApp/build/mlx-dspark.app
3. Navigate to Settings in the app, enable the newly introduced 'reasoning budget' feature and set the limit to 50 tokens.
4. Use the test prompt: "Prove sqrt(2) is irrational, carefully" which would ordinarily trigger a long response.
5. Note that after submitting a prompt, the model responds within 2 seconds, instead of thinking for 30 seconds (M5 Max) as it would otherwise.

Here is the inspiration from LM Studio Bionic:
<img width="683" height="202" alt="Screenshot 2026-08-20 at 11 07 56 am" src="https://github.com/user-attachments/assets/0b7fbc67-1062-4e04-8abd-402885a03cb3" />

Here are screenshots from the modified branch of the mlx-dspark project (note the presence of "I have to answer now" in the chat, showing the insertion of the reasoning budget breach interruption):
<img width="1232" height="872" alt="Screenshot 2026-08-20 at 6 58 23 pm" src="https://github.com/user-attachments/assets/7c3859ae-91d7-4d4a-b70b-f11913f69610" />
<img width="1232" height="872" alt="Screenshot 2026-08-20 at 6 57 21 pm" src="https://github.com/user-attachments/assets/c628cc34-1b21-45cc-8943-e018543eb4de" />
<img width="412" height="851" alt="Screenshot 2026-08-20 at 6 57 13 pm" src="https://github.com/user-attachments/assets/9dc73b4d-ecf1-45bf-82a7-491bb04668b4" />

Thinking budget is also verified as working in external harnesses like Claude Code, however please note the large system prompt and tool definitions (24k total tokens) incurs a significant delay until first response, regardless of how brief the prompt is or how quickly the thinking is interrupted by the budget feature:

<img width="853" height="971" alt="Screenshot 2026-08-20 at 7 52 29 pm" src="https://github.com/user-attachments/assets/123ea6fe-447e-4a94-8c4c-1f11359bfb77" />

The following summary of changes implemented is generated by Fable:

## Commits (2, reviewable independently)

**1. Engine** (`src/`, `tests/`, README)
- `ThinkBudget` (generate.py): text-level detection over committed tokens via the existing `ThinkingStreamSplitter`; one forced verify/prefill injects the close. Round-granular, fires at most once, disarmed if the model closes its own block, hold-fires while the tail could be completing the closer, injected tokens count against `max_tokens`. Muse/harmony models excluded.
- Injection sites in `speculative_generate`, `dflash_generate` (DFlash's deferred `pending_ctx` is concatenated, not overwritten), `lookup_generate`, and `greedy_generate` (both pipelined branches, with post-injection stop checks).
- API: per-request `reasoning_budget` / `reasoning_budget_message` (OpenAI) and `thinking.budget_tokens` (Anthropic — previously accepted-and-ignored, now enforced; `type: "disabled"` disables). Under `--max-batch`, an **explicitly requested** budget runs serially (exact enforcement); an ambient server default never costs batching — batched rows just don't enforce it.
- `POST /admin/config`: mutates the server-default reasoning knobs on the live engine with **no reload** (the handlers read them per request), works in the `--no-model` state via the stored load kwargs, validates the whole patch before mutating (a 400 never leaves a partial update), and writes through the `EngineHolder`/`BatchEngine` wrappers to the innermost engine so `__getattr__` delegation is never shadowed. Deliberately lock-free to match the codebase: a config landing inside an in-flight swap's copy-to-publish window is an accepted single-writer limitation, documented in the handler (and the app re-pushes after every load, so it never hits it).
- `/health`: `reasoning_budget`, `reasoning_budget_message`, `enable_thinking`, and capability flags `admin_config` / `supports_reasoning_budget` (false on muse models — a per-request budget control should gate on this, not `admin_config`).
- **Also fixes a pre-existing bug this work surfaced**: on prefilled-opener templates (the rendered prompt ends inside `<think>`), a non-streaming response truncated by `max_tokens` has neither opener nor closer, and the whole chain-of-thought leaked into `content`. `split_thinking`/`build_message` now take the same `in_thinking` hint the streaming splitters already had; behavior is unchanged wherever the hint is absent.

**2. Mac app** (`apps/MacApp/`)
- Settings → Reasoning card mirroring the Bionic panel: Enable Thinking switch (explicit true/false both ways), Reasoning Budget checkbox + field, budget message field (`""` = the engine's close-silently mode, kept distinct from null end to end). Instant apply through `/admin/config`, serialized latest-wins (a small `Coalescer` in AppCore), gated on `admin_config`, disabled during model loads.
- Settings persist across launches by pushing the full persisted config right after `/health` first answers (before any model load — argv can't express an explicit thinking-ON), and re-pushing after every successful load.
- Per-chat budget in the chat settings popover: unchecked inherits the server setting, a value enforces it for that conversation only (persisted per session file, restored on select/relaunch), `0` lifts the budget for that chat even when the server default is on. Gated on `supports_reasoning_budget`, inert while the chat's Allow-thinking veto is off.

## Testing

- 595 pytest (25 new engine-loop tests with scripted fake targets/drafters asserting verify/rollback/context invariants; endpoint suites for both API dialects; command-level tests pinning the opt-in CLI defaults at the argparse boundary), 31 swift-testing, ruff clean.
- Real-weights verification on `mlx-community/Qwen3.8-27B-8bit` (+ DFlash2 drafter): a 14-check live E2E driving the server the way the app does — startup config push before any model exists, values surviving `Engine.load`, the default budget firing with a custom message, live reconfig obeyed by the very next request with the model resident (<1 s, no reload), per-request overrides (`0` disables; Anthropic `budget_tokens` beats the server default), thinking vetoes per-request and server-default, `""` closing the block silently, and the truncated-thinking fix landing the chain-of-thought in `reasoning_content` with `content` empty.
