### PR TITLE
Add OpenAI Responses API (/v1/responses) for Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `mlx-dspark`. Versions follow [SemVer](https://semver.org/) (pre-1.0: minor-ish features land as patch bumps).
 
+## [Unreleased]
+
+### Added
+- **OpenAI Responses API** (`POST /v1/responses`, streaming and non-streaming) — the dialect
+  [Codex](https://github.com/openai/codex) requires once its provider is configured with
+  `wire_api = "responses"` (Codex dropped Chat Completions support, so an OpenAI-compatible
+  server without this endpoint is invisible to it — see #138). `input` accepts a bare string
+  or the structured item list (`message`, `function_call`, `function_call_output`); `tools`
+  are accepted in the Responses API's flat shape and translated to whatever the loaded
+  model's own chat template expects, same as the Chat Completions and Anthropic dialects.
+  Stateless, like Ollama's implementation — no `previous_response_id` / server-side
+  conversation store, since a client resubmits its own history each request (Codex already
+  does this). New `responses_api.py` module, pure and model-free like `anthropic_api.py`.
+
 ## [0.17.1] — 2026-08-25 — LM Studio no double download + cached_tokens in usage
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -295,6 +295,20 @@ syntax (Hermes JSON, Gemma-4, and the XML `<function=>` form) — and a reasonin
 `<|channel>thought` output is lifted into proper Anthropic `thinking` blocks rather than leaking as
 prose.
 
+### Use it from Codex
+
+The server also speaks OpenAI's **Responses API**, the dialect [Codex](https://github.com/openai/codex)
+requires once its provider is configured with `wire_api = "responses"` (Codex dropped Chat Completions
+support). Point a `model_providers` entry in `~/.codex/config.toml` at the running server's `/v1` base
+URL and Codex talks to whatever's loaded, same as any other OpenAI-compatible client.
+
+Endpoints: `POST /v1/responses` (streaming and non-streaming). `input` accepts either a bare string
+or the structured item list (`message`, `function_call`, `function_call_output`), `tools` are accepted
+in the Responses API's flat shape, and multi-turn tool use round-trips through the same tool-syntax
+translation the Chat Completions and Anthropic dialects already use. This is a **stateless** Responses
+implementation, like Ollama's — no `previous_response_id` / server-side conversation store, since a
+client resubmits its own history each request (Codex does this already, so nothing is lost).
+
 **Measured** — each of these ran a real Claude Code session that read a buggy file and fixed it with
 the `Edit` tool (M4 Pro, `--no-thinking`, identical task):
 

--- a/src/mlx_dspark/cli.py
+++ b/src/mlx_dspark/cli.py
@@ -1,9 +1,10 @@
 """mlx-dspark command line.
 
 Subcommands:
-  serve      Start the API server: OpenAI (/v1/chat/completions) **and** Anthropic
-             (/v1/messages) on the same port, so LM Studio clients, the openai SDK, curl,
-             and Claude Code all talk to it.
+  serve      Start the API server: OpenAI Chat Completions (/v1/chat/completions), OpenAI
+             Responses (/v1/responses), **and** Anthropic Messages (/v1/messages) on the
+             same port, so LM Studio clients, the openai SDK, curl, Claude Code, and Codex
+             all talk to it.
   claude     Launch Claude Code against a running ``serve``, configured for this process
              only — your normal ``claude`` sessions are untouched.
   generate   One-shot local generation (DSpark / DFlash / lookup / baseline). This is also

--- a/src/mlx_dspark/responses_api.py
+++ b/src/mlx_dspark/responses_api.py
@@ -1,0 +1,291 @@
+"""OpenAI Responses API (``/v1/responses``) — the dialect **Codex** speaks.
+
+Codex posts to ``/v1/responses`` instead of ``/v1/chat/completions`` once its provider is
+configured with ``wire_api = "responses"``, so an OpenAI Chat-Completions-only server is
+invisible to it (the same gap ``anthropic_api.py`` closes for Claude Code). This module is
+the translation layer: Responses request -> the OpenAI-shaped message list the rest of
+mlx-dspark already speaks (:func:`~mlx_dspark.generate.encode_messages` +
+:func:`~mlx_dspark.tools.normalize_tool_messages`), and generated text/tool-calls ->
+Responses output items / SSE events.
+
+Pure and model-free (no MLX, no weights), same as ``anthropic_api.py`` — ``server.py`` owns
+the HTTP plumbing.
+
+Scope, deliberately: this is a *stateless single-turn* implementation, matching what Ollama
+ships (its own Responses support is documented as "non-stateful" — no ``previous_response_id``
+/ server-side conversation store). A client resubmits its own history every request (Codex
+does exactly this), so there's nothing to persist. Reasoning is captured in the non-streaming
+body (split out the same way the Chat Completions path already splits ``reasoning_content``)
+but is not surfaced as incremental streaming events — a streaming response only emits the
+answer text and any tool calls, which is what a client whose model is running with
+``enable_thinking=False`` (this server's Qwen3.8 default) actually produces anyway.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+
+
+def _resp_id() -> str:
+    return "resp_" + uuid.uuid4().hex
+
+
+def _item_id(prefix: str) -> str:
+    return f"{prefix}_" + uuid.uuid4().hex
+
+
+def error_body(message: str, etype: str = "invalid_request_error") -> dict:
+    return {"error": {"message": message, "type": etype, "code": None, "param": None}}
+
+
+def _flatten_input_text(content) -> str:
+    """A Responses ``content`` value -> plain text. Content is either a bare string or a list
+    of typed parts (``input_text``/``output_text``/``input_image``/``input_file``); join the
+    text parts and drop the rest — mirrors ``tools._flatten_content`` for the Chat dialect."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for p in content:
+        if isinstance(p, str):
+            parts.append(p)
+        elif isinstance(p, dict) and isinstance(p.get("text"), str):
+            parts.append(p["text"])
+    return "\n".join(parts)
+
+
+def convert_input(input_, instructions=None) -> list[dict]:
+    """Responses ``input`` (+ top-level ``instructions``) -> an OpenAI chat ``messages`` list.
+
+    ``input`` is either a bare string (shorthand for one user turn) or a list of items. Two
+    item shapes matter here beyond a plain message: ``function_call`` and
+    ``function_call_output`` — the tool-use round trip a client replays each request since
+    this server holds no state between calls (see module docstring). Anything else (bare
+    ``reasoning`` items a previous response emitted, etc.) is server-side context a stateless
+    backend has no use for on replay, so it's skipped rather than rejected — an unrecognized
+    item type must not 400, the same policy ``anthropic_api`` follows for unknown fields.
+    """
+    messages: list[dict] = []
+    if instructions:
+        messages.append({"role": "system", "content": instructions})
+    if isinstance(input_, str):
+        messages.append({"role": "user", "content": input_})
+        return messages
+    if not isinstance(input_, list):
+        return messages
+    for item in input_:
+        if not isinstance(item, dict):
+            continue
+        kind = item.get("type", "message")
+        if kind == "message":
+            role = item.get("role", "user")
+            messages.append({"role": role, "content": _flatten_input_text(item.get("content"))})
+        elif kind == "function_call":
+            args = item.get("arguments", "{}")
+            if not isinstance(args, str):
+                args = json.dumps(args, ensure_ascii=False)
+            messages.append({
+                "role": "assistant", "content": None,
+                "tool_calls": [{
+                    "id": item.get("call_id") or item.get("id") or _item_id("call"),
+                    "type": "function",
+                    "function": {"name": item.get("name", ""), "arguments": args},
+                }],
+            })
+        elif kind == "function_call_output":
+            out = item.get("output", "")
+            if not isinstance(out, str):
+                out = json.dumps(out, ensure_ascii=False)
+            messages.append({"role": "tool", "tool_call_id": item.get("call_id", ""),
+                             "content": out})
+        # else: reasoning items and anything future — skip, see docstring
+    return messages
+
+
+def convert_tools(tools) -> list[dict] | None:
+    """Responses tool defs (flat: ``{"type":"function","name","description","parameters"}``)
+    -> Chat Completions shape (nested under ``function``), which is what the rest of the
+    server (``schema_types``, the chat template's tool rendering) already expects."""
+    if not tools:
+        return None
+    out = []
+    for t in tools:
+        if not isinstance(t, dict) or t.get("type") != "function":
+            continue
+        if "function" in t:      # already nested; accept as-is
+            out.append(t)
+            continue
+        out.append({"type": "function", "function": {
+            "name": t.get("name"), "description": t.get("description", ""),
+            "parameters": t.get("parameters") or {"type": "object", "properties": {}},
+        }})
+    return out or None
+
+
+def _output_text_item(item_id: str, text: str) -> dict:
+    return {"id": item_id, "type": "message", "status": "completed", "role": "assistant",
+            "content": [{"type": "output_text", "text": text, "annotations": []}]}
+
+
+def _reasoning_item(text: str) -> dict:
+    return {"id": _item_id("rs"), "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": text}]}
+
+
+def _function_call_item(call_id: str, name: str, arguments: str, *, status="completed") -> dict:
+    return {"id": _item_id("fc"), "type": "function_call", "status": status,
+            "call_id": call_id, "name": name, "arguments": arguments}
+
+
+def build_response(*, resp_id: str, model: str, content: str, reasoning: str = "",
+                   tool_calls: list[dict] | None = None, input_tokens: int, output_tokens: int,
+                   finish_reason: str, created: int | None = None) -> dict:
+    """Non-streaming ``/v1/responses`` body. ``content``/``reasoning``/``tool_calls`` are
+    already split the way the Chat Completions path splits them (``server._run``) — this only
+    repackages the same three pieces of information into Responses output items, in the order
+    a real turn produces them: reasoning, then either the answer or the calls it made instead."""
+    output = []
+    if reasoning:
+        output.append(_reasoning_item(reasoning))
+    for tc in (tool_calls or []):
+        fn = tc.get("function", {})
+        output.append(_function_call_item(tc.get("id") or _item_id("call"),
+                                          fn.get("name", ""), fn.get("arguments", "{}")))
+    if content:
+        output.append(_output_text_item(_item_id("msg"), content))
+    status = "incomplete" if finish_reason == "length" else "completed"
+    body = {
+        "id": resp_id, "object": "response", "created_at": created or int(time.time()),
+        "status": status, "model": model, "output": output,
+        "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens,
+                  "total_tokens": input_tokens + output_tokens},
+    }
+    if status == "incomplete":
+        body["incomplete_details"] = {"reason": "max_output_tokens"}
+    return body
+
+
+class ResponseStream:
+    """Streaming ``/v1/responses`` events at round granularity, the Responses-API twin of
+    ``anthropic_api.MessageStream``. ``start()``/``delta()``/``finish()`` each return a list
+    of ``(event_name, payload)`` pairs ready for ``server._sse``."""
+
+    def __init__(self, *, model: str, input_tokens: int, resp_id: str | None = None,
+                created: int | None = None):
+        self.model = model
+        self.input_tokens = input_tokens
+        self.id = resp_id or _resp_id()
+        self.created = created or int(time.time())
+        self.seq = 0
+        self.msg_item_id = _item_id("msg")
+        self.text = ""
+        # Allocated lazily on the first text delta, not up front: a pure tool-call turn (the
+        # model calls a tool with no preceding text, same as `_run_stream_body`'s want_tools
+        # path) must never announce-then-close an empty message item that then isn't in the
+        # final `output` array — a client tracking items by id from the stream would see a
+        # completed item that vanishes from the response it supposedly belongs to.
+        self.msg_index = None
+
+    def _n(self) -> int:
+        self.seq += 1
+        return self.seq
+
+    def _base_response(self, status: str) -> dict:
+        return {"id": self.id, "object": "response", "created_at": self.created,
+                "status": status, "model": self.model, "output": []}
+
+    def start(self) -> list[tuple[str, dict]]:
+        resp = self._base_response("in_progress")
+        return [("response.created", {"type": "response.created", "response": resp,
+                                      "sequence_number": self._n()})]
+
+    def delta(self, piece: str) -> list[tuple[str, dict]]:
+        if not piece:
+            return []
+        events = []
+        if self.msg_index is None:
+            self.msg_index = 0
+            item = {"id": self.msg_item_id, "type": "message", "status": "in_progress",
+                   "role": "assistant", "content": []}
+            part = {"type": "output_text", "text": "", "annotations": []}
+            events.append(("response.output_item.added",
+                          {"type": "response.output_item.added", "output_index": self.msg_index,
+                           "item": item, "sequence_number": self._n()}))
+            events.append(("response.content_part.added",
+                          {"type": "response.content_part.added", "item_id": self.msg_item_id,
+                           "output_index": self.msg_index, "content_index": 0, "part": part,
+                           "sequence_number": self._n()}))
+        self.text += piece
+        events.append(("response.output_text.delta",
+                       {"type": "response.output_text.delta", "item_id": self.msg_item_id,
+                        "output_index": self.msg_index, "content_index": 0, "delta": piece,
+                        "sequence_number": self._n()}))
+        return events
+
+    def finish(self, *, finish_reason: str, output_tokens: int,
+              tool_calls: list[dict] | None = None) -> list[tuple[str, dict]]:
+        events = []
+        output = []
+        if self.msg_index is not None:
+            part = {"type": "output_text", "text": self.text, "annotations": []}
+            msg_item = {"id": self.msg_item_id, "type": "message", "status": "completed",
+                       "role": "assistant", "content": [part]}
+            events += [
+                ("response.output_text.done",
+                 {"type": "response.output_text.done", "item_id": self.msg_item_id,
+                  "output_index": self.msg_index, "content_index": 0, "text": self.text,
+                  "sequence_number": self._n()}),
+                ("response.content_part.done",
+                 {"type": "response.content_part.done", "item_id": self.msg_item_id,
+                  "output_index": self.msg_index, "content_index": 0, "part": part,
+                  "sequence_number": self._n()}),
+                ("response.output_item.done",
+                 {"type": "response.output_item.done", "output_index": self.msg_index,
+                  "item": msg_item, "sequence_number": self._n()}),
+            ]
+            output.append(msg_item)
+        # Tool calls land atomically once generation finishes — same limitation the Chat
+        # Completions streaming path documents (incremental tool-call streaming isn't
+        # reliable to reconstruct from XML/JSON markup that may split across chunks). Each
+        # gets a single added -> one-shot arguments delta -> done triple rather than N
+        # incremental argument deltas; a client that only accumulates delta text sees the
+        # same final arguments either way.
+        next_index = 1 if self.msg_index is not None else 0
+        for tc in (tool_calls or []):
+            i = next_index
+            next_index += 1
+            fn = tc.get("function", {})
+            call_id = tc.get("id") or _item_id("call")
+            name, args = fn.get("name", ""), fn.get("arguments", "{}")
+            item = _function_call_item(call_id, name, args, status="in_progress")
+            item_id = item["id"]
+            events += [
+                ("response.output_item.added",
+                 {"type": "response.output_item.added", "output_index": i, "item": item,
+                  "sequence_number": self._n()}),
+                ("response.function_call_arguments.delta",
+                 {"type": "response.function_call_arguments.delta", "item_id": item_id,
+                  "output_index": i, "delta": args, "sequence_number": self._n()}),
+                ("response.function_call_arguments.done",
+                 {"type": "response.function_call_arguments.done", "item_id": item_id,
+                  "output_index": i, "arguments": args, "sequence_number": self._n()}),
+            ]
+            done_item = {**item, "status": "completed"}
+            events.append(("response.output_item.done",
+                          {"type": "response.output_item.done", "output_index": i,
+                           "item": done_item, "sequence_number": self._n()}))
+            output.append(done_item)
+        status = "incomplete" if finish_reason == "length" else "completed"
+        resp = self._base_response(status)
+        resp["output"] = output
+        resp["usage"] = {"input_tokens": self.input_tokens, "output_tokens": output_tokens,
+                         "total_tokens": self.input_tokens + output_tokens}
+        if status == "incomplete":
+            resp["incomplete_details"] = {"reason": "max_output_tokens"}
+        final_type = "response.completed" if status == "completed" else "response.incomplete"
+        events.append((final_type, {"type": final_type, "response": resp,
+                                    "sequence_number": self._n()}))
+        return events

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -16,7 +16,9 @@ Design choices (deliberate):
     (accept length, tok/s) and at ``GET /metrics``.
 
 Endpoints: ``POST /v1/chat/completions`` (stream + non-stream), ``POST /v1/completions``,
-``GET /v1/models``, ``GET /health``, ``GET /metrics``.
+``POST /v1/messages`` (Anthropic — see ``anthropic_api.py``), ``POST /v1/responses`` (OpenAI
+Responses API — see ``responses_api.py``), ``GET /v1/models``, ``GET /health``,
+``GET /metrics``.
 """
 
 from __future__ import annotations
@@ -36,6 +38,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlsplit
 
 from . import anthropic_api as A
+from . import responses_api as R
 from .generate import (
     GenResult,
     StopStreaming,
@@ -2597,6 +2600,8 @@ def make_handler(engine: Engine, api_key: str | None):
                     return self._messages(req)
                 if route in ("/v1/messages/count_tokens", "/messages/count_tokens"):
                     return self._count_tokens(req)
+                if route in ("/v1/responses", "/responses"):
+                    return self._responses(req)
                 if route == "/admin/race":
                     return self._race(req)
             except (BrokenPipeError, ConnectionResetError):
@@ -2815,6 +2820,132 @@ def make_handler(engine: Engine, api_key: str | None):
             if prompt_ids is None:
                 return err
             self._send_json(200, {"input_tokens": len(prompt_ids)})
+
+        # -- OpenAI Responses API (the dialect Codex speaks once wire_api = "responses") --
+        def _responses(self, req: dict):
+            input_ = req.get("input")
+            if input_ is None:
+                return self._send_json(400, R.error_body("'input' is required"))
+            tools = R.convert_tools(req.get("tools"))
+            messages = R.convert_input(input_, req.get("instructions"))
+            if not messages:
+                return self._send_json(
+                    400, R.error_body("'input' must be a non-empty string or list"))
+            tkw = dict(engine.template_defaults)
+            if tools:
+                tkw["tools"] = tools
+            reasoning = req.get("reasoning")
+            if isinstance(reasoning, dict) and reasoning.get("effort"):
+                try:
+                    tkw["reasoning_effort"] = _reasoning_effort(reasoning["effort"])
+                except ValueError as e:
+                    return self._send_json(400, R.error_body(str(e)))
+            try:
+                prompt_ids = encode_messages(
+                    engine.tokenizer, normalize_tool_messages(messages), **tkw)
+            except Exception as e:  # noqa: BLE001 — any template failure is a 400, not a crash
+                return self._send_json(400, R.error_body(f"could not apply chat template: {e}"))
+            window = getattr(engine, "context_window", None)
+            if window and len(prompt_ids) >= window:
+                return self._send_json(400, R.error_body(
+                    f"prompt is {len(prompt_ids)} tokens, this model's context window is "
+                    f"{window}"))
+            temperature, top_p, top_k = _sampling(req, engine.sampling_defaults)
+            params = {
+                "max_tokens": _clamp_tokens(req.get("max_output_tokens"),
+                                            engine.default_max_tokens, engine.max_tokens_cap),
+                "temperature": temperature, "top_p": top_p, "top_k": top_k,
+                "stop": [], "seed": None,
+            }
+            model = req.get("model") or engine.model_id
+            resp_id = "resp_" + uuid.uuid4().hex
+            created = int(time.time())
+            if req.get("stream"):
+                return self._responses_stream(prompt_ids, params, model, len(prompt_ids),
+                                              tools, resp_id, created)
+            res = engine.generate(prompt_ids, on_text=None, **params)
+            reasoning_text, content = A.split_thinking(res.text)
+            tool_calls = None
+            if tools:
+                parsed, cleaned = parse_tool_calls(content, schema_types(tools))
+                if parsed:
+                    tool_calls, content = parsed, cleaned
+            body = R.build_response(
+                resp_id=resp_id, model=model, content=content, reasoning=reasoning_text,
+                tool_calls=tool_calls, input_tokens=len(prompt_ids),
+                output_tokens=res.num_tokens, finish_reason=res.finish_reason, created=created)
+            body["x_mlx_dspark"] = engine.spec_info(res)
+            self._send_json(200, body)
+
+        def _responses_stream(self, prompt_ids, params, model, input_tokens, tools,
+                              resp_id, created):
+            stream = R.ResponseStream(model=model, input_tokens=input_tokens, resp_id=resp_id,
+                                      created=created)
+            self._sse_start()
+            for name, payload in stream.start():
+                self._sse(payload, name)
+
+            # Same keep-alive / disconnect-detection shape as the Anthropic and Chat
+            # Completions streaming paths — see their comments (STREAM_KEEPALIVE_S) for why.
+            done = threading.Event()
+            gone = threading.Event()
+
+            def _heartbeat():
+                while not done.wait(STREAM_KEEPALIVE_S):
+                    try:
+                        self._sse_comment("keepalive")
+                    except OSError:
+                        gone.set()
+                        return
+
+            threading.Thread(target=_heartbeat, daemon=True).start()
+
+            # Reasoning is stripped rather than streamed as its own item (see
+            # responses_api.py's module docstring for why); a tool-call gate holds back
+            # partial markup the same way the Chat Completions `want_tools` path does —
+            # incremental tool-call streaming isn't reliable to reconstruct.
+            splitter = A.ThinkingStreamSplitter(
+                in_thinking=self._prompt_opens_thinking(prompt_ids))
+            gate = A._ToolGate()
+
+            def on_text(piece: str):
+                if gone.is_set():
+                    raise StopStreaming()
+                try:
+                    for kind, text in splitter.feed(piece):
+                        if kind == "reasoning" or not text:
+                            continue
+                        safe = gate.feed(text)
+                        if safe:
+                            for name, payload in stream.delta(safe):
+                                self._sse(payload, name)
+                except (BrokenPipeError, ConnectionResetError) as e:
+                    raise StopStreaming() from e
+
+            try:
+                res = engine.generate(prompt_ids, on_text=on_text, **params)
+            finally:
+                done.set()
+            if gone.is_set():
+                print(f"[serve] client disconnected mid-stream; generation stopped early "
+                      f"after {res.num_tokens} tokens", file=sys.stderr, flush=True)
+                return
+            for kind, text in splitter.feed("", final=True):
+                if kind == "reasoning" or not text:
+                    continue
+                safe = gate.feed(text)
+                if safe:
+                    for name, payload in stream.delta(safe):
+                        self._sse(payload, name)
+            tail = gate.buf[gate.sent:]
+            parsed, cleaned = parse_tool_calls(tail, schema_types(tools))
+            if cleaned:
+                for name, payload in stream.delta(cleaned):
+                    self._sse(payload, name)
+            for name, payload in stream.finish(finish_reason=res.finish_reason,
+                                               output_tokens=res.num_tokens,
+                                               tool_calls=parsed):
+                self._sse(payload, name)
 
         def _run(self, req: dict, prompt_ids: list[int], *, chat: bool):
             # request value > model's generation_config recommendation > library default —

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,471 @@
+"""OpenAI Responses API (`/v1/responses`) — the surface Codex talks to once its provider is
+configured with `wire_api = "responses"`.
+
+Two layers, both model-free, same split as `test_anthropic.py`:
+
+* the pure translation in ``responses_api`` (request -> chat messages, generated text/tool
+  calls -> output items / SSE events), tested directly;
+* the HTTP endpoints, tested against the same mock-engine harness `test_anthropic.py` and
+  `test_server.py` use, so routing, SSE framing, and the error envelope run in milliseconds
+  without weights.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+
+import pytest
+
+from mlx_dspark import responses_api as R
+from mlx_dspark import server as S
+from mlx_dspark.generate import GenResult
+
+# --------------------------------------------------------------------------- translation
+
+
+def test_convert_input_plain_string():
+    assert R.convert_input("hello") == [{"role": "user", "content": "hello"}]
+
+
+def test_convert_input_with_instructions():
+    msgs = R.convert_input("hello", instructions="be terse")
+    assert msgs == [{"role": "system", "content": "be terse"},
+                    {"role": "user", "content": "hello"}]
+
+
+def test_convert_input_message_items():
+    msgs = R.convert_input([
+        {"type": "message", "role": "user", "content": "hi"},
+        {"type": "message", "role": "assistant", "content": "hello"},
+    ])
+    assert msgs == [{"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"}]
+
+
+def test_convert_input_content_parts_are_flattened():
+    msgs = R.convert_input([{"type": "message", "role": "user",
+                            "content": [{"type": "input_text", "text": "a"},
+                                       {"type": "input_text", "text": "b"}]}])
+    assert msgs == [{"role": "user", "content": "a\nb"}]
+
+
+def test_convert_input_bare_message_without_type_defaults_to_message():
+    # some clients send {"role", "content"} without the "type": "message" wrapper
+    msgs = R.convert_input([{"role": "user", "content": "hi"}])
+    assert msgs == [{"role": "user", "content": "hi"}]
+
+
+def test_convert_input_function_call_round_trip():
+    msgs = R.convert_input([
+        {"type": "message", "role": "user", "content": "weather in Boston?"},
+        {"type": "function_call", "call_id": "call_1", "name": "get_weather",
+         "arguments": '{"city": "Boston"}'},
+        {"type": "function_call_output", "call_id": "call_1",
+         "output": '{"temp_f": 52}'},
+    ])
+    assert msgs == [
+        {"role": "user", "content": "weather in Boston?"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "call_1", "type": "function",
+             "function": {"name": "get_weather", "arguments": '{"city": "Boston"}'}}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"temp_f": 52}'},
+    ]
+
+
+def test_convert_input_function_call_output_serializes_non_string_output():
+    msgs = R.convert_input([
+        {"type": "function_call_output", "call_id": "call_1", "output": {"temp_f": 52}},
+    ])
+    assert json.loads(msgs[0]["content"]) == {"temp_f": 52}
+
+
+def test_convert_input_unknown_item_types_are_skipped_not_rejected():
+    # a prior response's reasoning item, replayed verbatim by a stateless client — this
+    # server has nothing to do with it, and it must not 400 (same policy anthropic_api
+    # follows for fields it doesn't implement)
+    msgs = R.convert_input([
+        {"type": "reasoning", "summary": [{"type": "summary_text", "text": "thinking..."}]},
+        {"type": "message", "role": "user", "content": "hi"},
+    ])
+    assert msgs == [{"role": "user", "content": "hi"}]
+
+
+def test_convert_input_non_list_non_string_returns_empty():
+    assert R.convert_input(None) == []
+    assert R.convert_input(42) == []
+
+
+def test_convert_tools_flattens_to_chat_completions_shape():
+    tools = R.convert_tools([{"type": "function", "name": "get_weather",
+                             "description": "d",
+                             "parameters": {"type": "object",
+                                           "properties": {"city": {"type": "string"}}}}])
+    assert tools == [{"type": "function", "function": {
+        "name": "get_weather", "description": "d",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}}]
+
+
+def test_convert_tools_accepts_already_nested_shape():
+    nested = [{"type": "function", "function": {"name": "f", "parameters": {}}}]
+    assert R.convert_tools(nested) == nested
+
+
+def test_convert_tools_defaults_missing_parameters():
+    tools = R.convert_tools([{"type": "function", "name": "f"}])
+    assert tools[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+
+
+def test_convert_tools_empty_and_none():
+    assert R.convert_tools(None) is None
+    assert R.convert_tools([]) is None
+
+
+def test_build_response_text_only():
+    body = R.build_response(resp_id="resp_1", model="m", content="hi", input_tokens=5,
+                            output_tokens=1, finish_reason="stop", created=100)
+    assert body["status"] == "completed"
+    assert body["output"] == [{
+        "id": body["output"][0]["id"], "type": "message", "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "hi", "annotations": []}]}]
+    assert body["usage"] == {"input_tokens": 5, "output_tokens": 1, "total_tokens": 6}
+
+
+def test_build_response_incomplete_on_length():
+    body = R.build_response(resp_id="resp_1", model="m", content="cut off", input_tokens=5,
+                            output_tokens=10, finish_reason="length", created=100)
+    assert body["status"] == "incomplete"
+    assert body["incomplete_details"] == {"reason": "max_output_tokens"}
+
+
+def test_build_response_order_is_reasoning_then_tool_calls_then_text():
+    body = R.build_response(
+        resp_id="resp_1", model="m", content="answer", reasoning="thinking",
+        tool_calls=[{"id": "call_1", "function": {"name": "f", "arguments": "{}"}}],
+        input_tokens=5, output_tokens=1, finish_reason="stop", created=100)
+    types = [item["type"] for item in body["output"]]
+    assert types == ["reasoning", "function_call", "message"]
+
+
+def test_build_response_no_reasoning_no_tool_calls_omits_them():
+    body = R.build_response(resp_id="resp_1", model="m", content="hi", input_tokens=1,
+                            output_tokens=1, finish_reason="stop", created=100)
+    assert len(body["output"]) == 1
+    assert body["output"][0]["type"] == "message"
+
+
+# --------------------------------------------------------------------------- ResponseStream
+
+
+def _names(events):
+    return [name for name, _ in events]
+
+
+def test_stream_plain_text_event_sequence():
+    s = R.ResponseStream(model="m", input_tokens=5)
+    start = _names(s.start())
+    assert start == ["response.created"]
+    d = _names(s.delta("hello"))
+    assert d == ["response.output_item.added", "response.content_part.added",
+                "response.output_text.delta"]
+    f = _names(s.finish(finish_reason="stop", output_tokens=1))
+    assert f == ["response.output_text.done", "response.content_part.done",
+                "response.output_item.done", "response.completed"]
+
+
+def test_stream_second_delta_does_not_reopen_the_item():
+    s = R.ResponseStream(model="m", input_tokens=5)
+    s.start()
+    first = _names(s.delta("a"))
+    second = _names(s.delta("b"))
+    assert first == ["response.output_item.added", "response.content_part.added",
+                     "response.output_text.delta"]
+    assert second == ["response.output_text.delta"]
+
+
+def test_stream_empty_delta_is_a_no_op():
+    s = R.ResponseStream(model="m", input_tokens=5)
+    assert s.delta("") == []
+    assert s.delta(None) == []
+
+
+def test_stream_pure_tool_call_never_opens_a_message_item():
+    # a turn where the model only calls a tool (no preceding text) must not announce and
+    # then close an empty message item that then isn't in the final `output` array
+    s = R.ResponseStream(model="m", input_tokens=5)
+    s.start()
+    events = s.finish(finish_reason="tool_calls", output_tokens=3,
+                      tool_calls=[{"id": "call_1",
+                                  "function": {"name": "f", "arguments": "{}"}}])
+    names = _names(events)
+    assert "response.output_item.added" in names
+    assert "response.output_text.done" not in names   # no message item was ever opened
+    completed = dict(events)["response.completed"]
+    types = [item["type"] for item in completed["response"]["output"]]
+    assert types == ["function_call"]                 # nothing phantom in the final output
+
+
+def test_stream_text_then_tool_call_indices_are_sequential():
+    s = R.ResponseStream(model="m", input_tokens=5)
+    s.start()
+    s.delta("checking...")
+    events = s.finish(finish_reason="tool_calls", output_tokens=3,
+                      tool_calls=[{"id": "call_1",
+                                  "function": {"name": "f", "arguments": "{}"}}])
+    added = [payload for name, payload in events if name == "response.output_item.added"]
+    assert [a["output_index"] for a in added] == [1]     # message already claimed index 0
+    completed = dict(events)["response.completed"]
+    types = [item["type"] for item in completed["response"]["output"]]
+    assert types == ["message", "function_call"]
+
+
+def test_stream_multiple_tool_calls_get_increasing_indices():
+    s = R.ResponseStream(model="m", input_tokens=5)
+    s.start()
+    events = s.finish(finish_reason="tool_calls", output_tokens=3, tool_calls=[
+        {"id": "call_1", "function": {"name": "f", "arguments": "{}"}},
+        {"id": "call_2", "function": {"name": "g", "arguments": "{}"}},
+    ])
+    added = [payload for name, payload in events if name == "response.output_item.added"]
+    assert [a["output_index"] for a in added] == [0, 1]
+
+
+def test_stream_sequence_numbers_are_monotonic():
+    s = R.ResponseStream(model="m", input_tokens=5)
+    events = s.start() + s.delta("hi") + s.finish(finish_reason="stop", output_tokens=1)
+    seqs = [payload["sequence_number"] for _, payload in events]
+    assert seqs == sorted(seqs) == list(range(1, len(seqs) + 1))
+
+
+def test_stream_completed_response_carries_usage():
+    s = R.ResponseStream(model="m", input_tokens=7)
+    s.start()
+    s.delta("hi")
+    events = s.finish(finish_reason="stop", output_tokens=2)
+    completed = dict(events)["response.completed"]
+    assert completed["response"]["usage"] == {"input_tokens": 7, "output_tokens": 2,
+                                              "total_tokens": 9}
+
+
+def test_stream_incomplete_emits_response_incomplete_not_completed():
+    s = R.ResponseStream(model="m", input_tokens=5)
+    s.start()
+    s.delta("cut off")
+    events = s.finish(finish_reason="length", output_tokens=100)
+    names = _names(events)
+    assert "response.incomplete" in names
+    assert "response.completed" not in names
+
+
+# --------------------------------------------------------------------------- HTTP endpoint
+
+
+class _FakeTok:
+    """Deterministic, template-free: encode() is 1 id per character."""
+
+    def encode(self, text):
+        return [ord(c) for c in text]
+
+    def decode(self, ids):
+        return "".join(chr(int(i) % 0x110000) for i in ids)
+
+
+class _FakeEngine:
+    mode = "dspark"
+    model_id = "FakeModel"
+    created = 123
+    target_repo = "org/Target"
+    drafter_repo = "org/Drafter"
+    template_defaults = {}
+    sampling_defaults = {}
+    default_max_tokens = 2048
+    max_tokens_cap = 32768
+    cap_controller = None
+    context_window = None
+    is_muse = False
+
+    def __init__(self, response_text="Hello world"):
+        self.tokenizer = _FakeTok()
+        self.calls = []
+        self.response_text = response_text
+
+    def generate(self, prompt_ids, *, max_tokens, temperature, top_p=1.0, top_k=0,
+                presence_penalty=0.0, frequency_penalty=0.0, logprobs=None,
+                stop=None, seed=None, on_text=None):
+        self.calls.append({"prompt_ids": prompt_ids, "max_tokens": max_tokens,
+                               "temperature": temperature, "stop": stop, "seed": seed})
+        text = self.response_text
+        if on_text:
+            for i in range(0, len(text), 5):
+                on_text(text[i:i + 5])
+        return GenResult(text=text, token_ids=[1, 2, 3], num_tokens=3, num_rounds=2,
+                         accept_lengths=[2, 1], target_forwards=2, seconds=0.1,
+                         finish_reason="stop")
+
+    def spec_info(self, res):
+        return {"mode": self.mode, "accept_len": res.mean_accept_len}
+
+    def metrics(self):
+        return {"model": self.model_id, "requests": len(self.calls)}
+
+
+def _serve(engine, api_key=None):
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), S.make_handler(engine, api_key=api_key))
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"
+
+
+@pytest.fixture
+def api():
+    eng = _FakeEngine()
+    httpd, base = _serve(eng)
+    yield eng, base
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def _post(base, path, body, raw=False, timeout=10):
+    req = urllib.request.Request(base + path, data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        text = r.read().decode()
+    return text if raw else json.loads(text)
+
+
+def _read_sse(body: str):
+    out = []
+    for block in body.strip().split("\n\n"):
+        name = data = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                name = line[len("event: "):]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: "):])
+        if data is not None:
+            out.append((name, data))
+    return out
+
+
+def test_responses_non_streaming(api):
+    _, base = api
+    r = _post(base, "/v1/responses", {"model": "gpt-4o", "input": "hi",
+                                      "max_output_tokens": 100})
+    assert r["object"] == "response" and r["status"] == "completed"
+    assert r["model"] == "gpt-4o"      # echoed back, as a gateway would
+    assert r["output"][0]["content"][0]["text"] == "Hello world"
+    assert r["usage"]["output_tokens"] == 3
+
+
+def test_responses_input_reaches_the_engine_as_a_user_message(api):
+    eng, base = api
+    _post(base, "/v1/responses", {"input": "hi there", "max_output_tokens": 10})
+    assert len(eng.calls) == 1
+    assert eng.calls[0]["prompt_ids"] == [ord(c) for c in "hi there"]
+
+
+def test_responses_missing_input_is_a_400(api):
+    _, base = api
+    req = urllib.request.Request(base + "/v1/responses",
+                                 data=json.dumps({"model": "m"}).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with pytest.raises(urllib.error.HTTPError) as e:
+        urllib.request.urlopen(req, timeout=10)
+    assert e.value.code == 400
+    body = json.loads(e.value.read().decode())
+    assert "input" in body["error"]["message"]
+
+
+def test_responses_max_output_tokens_is_clamped_to_the_server_cap(api):
+    eng, base = api
+    _post(base, "/v1/responses", {"input": "hi", "max_output_tokens": 999999})
+    assert eng.calls[0]["max_tokens"] == eng.max_tokens_cap
+
+
+def test_responses_streaming_event_sequence(api):
+    _, base = api
+    body = _post(base, "/v1/responses",
+                {"input": "hi", "max_output_tokens": 100, "stream": True}, raw=True)
+    events = _read_sse(body)
+    names = [n for n, _ in events]
+    assert names[0] == "response.created"
+    assert names[-1] == "response.completed"
+    assert "response.output_text.delta" in names
+    full_text = "".join(p["delta"] for n, p in events if n == "response.output_text.delta")
+    assert full_text == "Hello world"
+
+
+def test_responses_streaming_usage_in_final_event(api):
+    _, base = api
+    body = _post(base, "/v1/responses",
+                {"input": "hi", "max_output_tokens": 100, "stream": True}, raw=True)
+    events = dict(_read_sse(body))
+    assert events["response.completed"]["response"]["usage"]["output_tokens"] == 3
+
+
+def test_responses_tool_call_round_trip_reaches_the_model(api):
+    eng, base = api
+    eng.response_text = "irrelevant for this assertion"
+    tools = [{"type": "function", "name": "get_weather",
+             "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}]
+    _post(base, "/v1/responses", {
+        "input": [
+            {"type": "message", "role": "user", "content": "weather in Boston?"},
+            {"type": "function_call", "call_id": "call_1", "name": "get_weather",
+             "arguments": '{"city": "Boston"}'},
+            {"type": "function_call_output", "call_id": "call_1", "output": "sunny, 70F"},
+        ],
+        "tools": tools, "max_output_tokens": 100,
+    })
+    # the tool round trip must survive normalize_tool_messages and reach the template as
+    # real text the fake (template-free) tokenizer can encode — not raise or vanish
+    assert len(eng.calls) == 1
+    assert eng.calls[0]["prompt_ids"]
+
+
+def test_responses_model_emitting_a_tool_call_is_reported_as_a_function_call(api):
+    eng, base = api
+    eng.response_text = '<tool_call>{"name": "get_weather", "arguments": {"city": "NYC"}}</tool_call>'
+    tools = [{"type": "function", "name": "get_weather",
+             "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}]
+    r = _post(base, "/v1/responses", {"input": "weather?", "tools": tools,
+                                      "max_output_tokens": 100})
+    assert r["output"][0]["type"] == "function_call"
+    assert r["output"][0]["name"] == "get_weather"
+    assert json.loads(r["output"][0]["arguments"]) == {"city": "NYC"}
+
+
+def test_responses_streaming_tool_call_never_leaks_native_syntax_as_text(api):
+    eng, base = api
+    eng.response_text = '<tool_call>{"name": "get_weather", "arguments": {}}</tool_call>'
+    tools = [{"type": "function", "name": "get_weather", "parameters": {}}]
+    body = _post(base, "/v1/responses", {"input": "weather?", "tools": tools,
+                                         "max_output_tokens": 100, "stream": True}, raw=True)
+    events = _read_sse(body)
+    for name, payload in events:
+        if name == "response.output_text.delta":
+            assert "<tool_call>" not in payload["delta"]
+    completed = dict(events)["response.completed"]
+    types = [item["type"] for item in completed["response"]["output"]]
+    assert "function_call" in types
+
+
+def test_responses_openai_route_still_works_alongside(api):
+    # adding /v1/responses must not disturb the existing Chat Completions route
+    _, base = api
+    r = _post(base, "/v1/chat/completions",
+             {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 10})
+    assert r["object"] == "chat.completion"
+
+
+def test_responses_unknown_request_fields_never_fail(api):
+    # Codex's own field set grows across releases; an unrecognised field must not 400
+    _, base = api
+    r = _post(base, "/v1/responses", {"input": "hi", "max_output_tokens": 10,
+                                      "parallel_tool_calls": True, "store": False,
+                                      "previous_response_id": None, "metadata": {"a": 1}})
+    assert r["object"] == "response"


### PR DESCRIPTION
## Summary

Codex requires `wire_api = "responses"` and dropped Chat Completions support, so this server was invisible to it — filed as #138. This adds `POST /v1/responses` (streaming and non-streaming) alongside the existing Chat Completions and Anthropic Messages endpoints.

- New `responses_api.py` mirrors `anthropic_api.py`'s pure, model-free translation-layer pattern: Responses request → the OpenAI chat message list `encode_messages` already speaks, generated text/tool calls → Responses output items and SSE events. `server.py` gains two handler methods (`_responses`/`_responses_stream`) that reuse the existing engine, tool-parsing, and thinking-split machinery — no changes to generation itself.
- `input` accepts either a bare string or the structured item list (`message`, `function_call`, `function_call_output`); `tools` are accepted in the Responses API's flat shape and converted to the nested Chat Completions shape the rest of the server already expects.
- Stateless, like Ollama's own Responses implementation (verified against a locally installed Ollama 0.32.9 as a reference for event shapes) — no `previous_response_id` / server-side conversation store, since a client resubmits its own history each request and Codex already does exactly that.
- Streaming allocates the message item lazily on the first text delta rather than announcing it up front — a pure-tool-call turn (no preceding text) no longer opens-then-closes an empty message item that then doesn't appear in the final response's `output` array.

## Test plan

- [x] 37 new tests in `tests/test_responses.py`: pure translation (`convert_input`, `convert_tools`, `build_response`, `ResponseStream` event sequencing incl. the lazy-item-open case) + HTTP-level tests against the existing mock-engine harness (non-streaming, streaming, tool-call round trips, error envelope, max-tokens clamping, unknown-field tolerance).
- [x] Full existing suite (`pytest tests/`) still passes: 576/579, unchanged from `main` — the 3 failures are pre-existing floating-point tolerance flakiness in `test_bonsai.py`/`test_dflash2.py` (confirmed identical on unmodified `main` via `git stash`), untouched by this change.
- [x] `ruff check` clean.
- [x] Verified end-to-end against a live `Qwen3.8-27B` (DFlash2) server on real hardware: non-streaming, streaming, a full tool-call round trip (model emits `function_call` → client replays `function_call_output` → model answers using it), text-then-tool-call ordering, and the missing-`input` error case — all through the real HTTP path, not just the mock harness.