### PR TITLE
Report per-request prefix-cache hits in OpenAI usage (prompt_tokens_details.cached_tokens)

### DIFF
--- a/src/mlx_dspark/generate.py
+++ b/src/mlx_dspark/generate.py
@@ -57,6 +57,7 @@ class GenResult:
     finish_reason: str = "stop"  # "stop" (eos/stop-string) | "length" (hit max_new_tokens)
     lookup_rounds: int = 0       # rounds whose draft came from the free n-gram lookup
     logprobs: list | None = None  # per-token [{token_id, logprob, top:[(id, logprob), …]}], if requested
+    cache_read: int = 0          # prefix-cache tokens reused for this request (set by the engine)
 
     @property
     def mean_accept_len(self) -> float:

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -743,6 +743,10 @@ class Engine:
             # drafter ctx window can't serve trim-mode reuse, so a post-generation trim
             # slot would be a broken promise on a dense target (see _build_prefix_cache).
             self.prefix.store(cache, ctx, prompt_ids, res.token_ids)
+        # Expose the per-request prefix-cache reuse so the OpenAI usage block can
+        # report prompt_tokens_details.cached_tokens (OpenAI-compatible clients
+        # measure cache hits from there).
+        res.cache_read = reuse_len
         self.stats["requests"] += 1
         self.stats["prompt_tokens"] += len(prompt_ids)
         self.stats["completion_tokens"] += res.num_tokens
@@ -2313,6 +2317,7 @@ def make_handler(engine: Engine, api_key: str | None):
                 "prompt_tokens": len(prompt_ids),
                 "completion_tokens": gen_tokens,
                 "total_tokens": len(prompt_ids) + gen_tokens,
+                "prompt_tokens_details": {"cached_tokens": res_list[0].cache_read},
             }
             choices = []
             for i, res in enumerate(res_list):
@@ -2413,6 +2418,7 @@ def make_handler(engine: Engine, api_key: str | None):
                     "prompt_tokens": len(prompt_ids),
                     "completion_tokens": res.num_tokens,
                     "total_tokens": len(prompt_ids) + res.num_tokens,
+                    "prompt_tokens_details": {"cached_tokens": res.cache_read},
                 }
             final["x_mlx_dspark"] = engine.spec_info(res)
             self._sse(final)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -122,6 +122,7 @@ def test_chat_non_stream(server):
     assert c["choices"][0]["finish_reason"] == "stop"
     assert c["usage"]["completion_tokens"] == 5 and c["usage"]["prompt_tokens"] > 0
     assert c["usage"]["total_tokens"] == c["usage"]["prompt_tokens"] + 5
+    assert c["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
     assert "x_mlx_dspark" in c
 
 
@@ -139,6 +140,7 @@ def test_chat_stream_sse(server):
     assert content == "Hello world from mlx dspark "
     assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
     assert chunks[-1]["usage"]["completion_tokens"] == 5
+    assert chunks[-1]["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
 
 
 def test_stop_forwarded(server):


### PR DESCRIPTION
## What

OpenAI-compatible usage responses now report how many prompt tokens of that
request were served from the prefix cache, in both the non-streaming body and
the streaming final chunk: `usage.prompt_tokens_details.cached_tokens`.

## Why

Clients (OpenAI-compatible SDKs, DeepSeek Harness's pi-ai adapter, …) measure
cache-hit rates from this field. The engine already computes the exact
per-request reuse (`PrefixCache.acquire` returns `reuse_len`), but the number
never reached the usage block, so clients always observed 0% cache hits.

## Change

- `GenResult` gains a `cache_read: int = 0` field.
- `Engine._generate_impl` sets it from the acquire result.
- Both usage blocks emit `prompt_tokens_details.cached_tokens`.
- Batched rows skip prefix reuse and keep the default 0, matching reality.
- Extended `test_chat_non_stream` / `test_chat_stream_sse` to assert the field.

## Verification

- Repeated identical request reports 63/64 cached tokens.
- A growing 2-turn conversation reuses the full prefix (8469/8497).
