### PR TITLE
Show live prefill progress in the Mac app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `mlx-dspark`. Versions follow [SemVer](https://semver.org/) (pre-1.0: minor-ish features land as patch bumps).
 
+## [Unreleased]
+
+### Fixed
+- **CPU co-prefill is now off by default.** Two long-prefill runs reproducibly crashed inside MLX's bf16 BNNS CPU matmul (`EXC_BAD_ACCESS`). The Mac app's Advanced toggle and `/admin/load {"cpu_split":"auto"}` explicitly opt into the existing per-Mac/model calibration for the current server session; `--cpu-split FRAC` remains the fixed-fraction A/B knob.
+
 ## [0.17.2] — 2026-08-27 — Codex support (Responses API) + the dflash default cap is measured, not assumed
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ mlx-dspark serve --model mlx-community/Qwen3-8B-8bit        # → http://127.0.0
 #                   admits the next one mid-flight)
 #   --kv-bits 8     quantized KV cache (long-context bandwidth saver)
 #   --mode auto|dspark|dflash|lookup|baseline   ·   --no-thinking   ·   --api-key KEY
-#   --cpu-split 0   turn off CPU co-prefill (default: a calibrated share of each wide prefill
-#                   matmul runs on the CPU's matrix units alongside the GPU — ~1.3–1.4× prefill)
+#   --cpu-split FRAC   opt into CPU co-prefill with this row share (off by default;
+#                      ~1.3–1.4× prefill on the measured M4 Pro configurations)
 #   --trust-remote-code   allow a checkpoint's own Python to be imported (refused by default)
 #   --reasoning-effort low|medium|xhigh   default reasoning depth on models that support it
 #                   (Qwen3.8-class; /health reports support, requests can override)
@@ -762,10 +762,10 @@ of your wall clock is **prefill**: reading the prompt. For a chat message that i
 pasted file, a long conversation, or an agent (Claude Code sends **~18–26k tokens every request**) it
 is most of the time you wait.
 
-Measured on an M4 Pro, median of 3, default settings. Since the **CPU co-prefill** pass
-(unreleased) the CLI/server also run a calibrated share of every wide matmul on the CPU's matrix
-units, concurrently with the GPU — the "before → after" pairs below are the same process with it
-forced off (`--cpu-split 0`) vs on, 2048-token prompt (the ratio holds at 4096):
+Measured on an M4 Pro, median of 3. The **CPU co-prefill** column opts into a calibrated
+share of every wide matmul on the CPU's matrix units, concurrently with the GPU — the
+"before → after" pairs below are the same process with it off vs explicitly on, 2048-token
+prompt (the ratio holds at 4096):
 
 | target | prefill | with CPU co-prefill | a 20k-token prompt takes |
 |---|---|---|---|
@@ -798,12 +798,11 @@ on this M4 Pro) to MLX's CPU stream, which runs on the CPU's matrix units at ~3 
 GPU does the rest* — same arrays, no copy, no new dependency, no second thread. That is the
 **1.29–1.41×** column above, +0.4 GB peak RAM. It is not bit-identical (the CPU rows accumulate in
 a different order — the same fp-tie class as chunked prefill, and a 64-token greedy continuation
-came out token-identical), so the CLI and server turn it on and the library API leaves it off;
-`--cpu-split 0` disables it, `/health.cpu_split` shows the calibrated setting, and the fraction
-is measured once per machine+model because it is an optimum with a cliff, not a knob (0.45 is
-already slower than 0.30). Nothing to configure: the first load of each model after upgrading
-spends ~15 s calibrating (cached from then on, printed in the serve banner), and every mode —
-including the default `auto` and the Mac app — gets it. The Apple Neural Engine was measured for the same job and does not
+came out token-identical), so it is off by default; `--cpu-split FRAC` explicitly enables it and
+`/health.cpu_split` shows the live setting. The Mac app's Advanced controls can opt into the
+per-Mac/model calibration for the current server session (a restart safely turns it off again),
+as can `/admin/load {"cpu_split":"auto"}`. Fixed fractions remain a CLI/API A/B knob because the
+optimum is hardware-sensitive; 0.45 is already slower than 0.30 on the measured M4 Pro. The Apple Neural Engine was measured for the same job and does not
 fit: its fast weight formats can't hold mlx's group-quantized weights exactly, and the exact fp16
 form is a 34 GB copy of a 27B's MLP — see NOTES "CPU co-prefill". The remaining lever is still not
 prefilling at all, which is what [prefix caching](#prefix-caching) does.

--- a/apps/MacApp/Sources/AppCore/APIClient.swift
+++ b/apps/MacApp/Sources/AppCore/APIClient.swift
@@ -388,6 +388,10 @@ public struct APIClient: Sendable {
                             if let stats = try? decoder.decode(RoundStats.self, from: data) {
                                 continuation.yield(.stats(stats))
                             }
+                        case "prefill":
+                            if let progress = try? decoder.decode(PrefillEvent.self, from: data) {
+                                continuation.yield(.prefill(progress))
+                            }
                         default:
                             if let round = try? decoder.decode(RoundEvent.self, from: data) {
                                 continuation.yield(.round(round))

--- a/apps/MacApp/Sources/AppCore/APIClient.swift
+++ b/apps/MacApp/Sources/AppCore/APIClient.swift
@@ -7,6 +7,12 @@ import Foundation
 // (accept length, cap, lookup rounds), so it is a first-class type here, not an afterthought.
 
 public struct HealthInfo: Decodable, Sendable, Equatable {
+    public struct CPUSplitInfo: Decodable, Sendable, Equatable {
+        public let minRows: Int
+
+        enum CodingKeys: String, CodingKey { case minRows = "min_rows" }
+    }
+
     /// `ok` (model loaded) · `loading` (swap in flight) · `no_model` (server up, nothing
     /// loaded — the fast-launch/unloaded state). Older engines only ever report `ok` here;
     /// their loading state was undecodable and surfaced as a failed request instead.
@@ -54,6 +60,8 @@ public struct HealthInfo: Decodable, Sendable, Equatable {
     /// `/admin/load` override, so the picker hides then (a control that silently does
     /// nothing is worse than none).
     public let kvBits: Int?
+    /// Non-nil when experimental CPU co-prefill is active for this load.
+    public let cpuSplit: CPUSplitInfo?
     /// Banner-worthy conditions: live macOS memory pressure and the engine's load-time notes
     /// (e.g. "this context window's KV cache can't fit alongside the weights"). Optional:
     /// older engines don't report it.
@@ -75,6 +83,7 @@ public struct HealthInfo: Decodable, Sendable, Equatable {
         case raceArmConfidence = "race_arm_confidence"
         case lookupDrafts = "lookup_drafts"
         case kvBits = "kv_bits"
+        case cpuSplit = "cpu_split"
     }
 
     /// True when a model is loaded and serving (`status == "ok"`).
@@ -271,6 +280,7 @@ public struct APIClient: Sendable {
                           contextWindow: Int? = nil,
                           lookupDrafts: Bool? = nil,
                           kvBits: Int? = nil,
+                          cpuPrefill: Bool? = nil,
                           enableThinking: Bool? = nil) async throws -> LoadStatus {
         var payload: [String: Any] = ["model": target]
         if let mode { payload["mode"] = mode }
@@ -286,6 +296,10 @@ public struct APIClient: Sendable {
         // KV-cache quantization (issue #17): 0 = explicitly full precision, 4/8 = quantized;
         // nil = keep the server's setting. The caller gates on /health.kv_bits presence.
         if let kvBits { payload["kv_bits"] = kvBits }
+        // App choice is deliberately only off/automatic; fixed fractions remain a CLI knob.
+        if let cpuPrefill {
+            payload["cpu_split"] = cpuPrefill ? "auto" : 0
+        }
         // Thinking default for API clients (issue #19): false = off unless a request asks,
         // true = the model's own default; nil = keep. Sticky across later swaps server-side.
         if let enableThinking { payload["enable_thinking"] = enableThinking }

--- a/apps/MacApp/Sources/AppCore/ServerSupervisor.swift
+++ b/apps/MacApp/Sources/AppCore/ServerSupervisor.swift
@@ -31,11 +31,17 @@ public struct ServerConfig: Equatable, Sendable {
     /// 0.17.1; older engines ignore the variable) — a GUI app is the only way most users can
     /// set an environment variable for the engine at all.
     public var modelDirs: [String]
+    public var confidenceThreshold: Double
+    public var lookupDrafts: Bool?
+    public var kvBits: Int?
+    public var enableThinking: Bool?
 
     public init(model: String? = nil, mode: String = "auto", maxDraft: String? = "auto",
                 contextWindow: Int? = nil,
                 host: String = "127.0.0.1", apiKey: String? = nil, port: Int = 0,
-                portIsExplicit: Bool = true, modelDirs: [String] = []) {
+                portIsExplicit: Bool = true, modelDirs: [String] = [],
+                confidenceThreshold: Double = 0.0, lookupDrafts: Bool? = nil,
+                kvBits: Int? = nil, enableThinking: Bool? = nil) {
         self.model = model
         self.mode = mode
         self.maxDraft = maxDraft
@@ -45,6 +51,10 @@ public struct ServerConfig: Equatable, Sendable {
         self.port = port
         self.portIsExplicit = portIsExplicit
         self.modelDirs = modelDirs
+        self.confidenceThreshold = confidenceThreshold
+        self.lookupDrafts = lookupDrafts
+        self.kvBits = kvBits
+        self.enableThinking = enableThinking
     }
 
     /// Serve on every interface (`0.0.0.0`) or loopback only.
@@ -140,6 +150,16 @@ public actor ServerSupervisor {
         if let contextWindow = config.contextWindow {
             args.append(contentsOf: ["--context-window", String(contextWindow)])
         }
+        if config.confidenceThreshold != 0 {
+            args.append(contentsOf: ["--confidence-threshold", String(config.confidenceThreshold)])
+        }
+        if let lookupDrafts = config.lookupDrafts {
+            args.append(lookupDrafts ? "--lookup-drafts" : "--no-lookup-drafts")
+        }
+        if let kvBits = config.kvBits {
+            args.append(contentsOf: ["--kv-bits", String(kvBits)])
+        }
+        if config.enableThinking == false { args.append("--no-thinking") }
         if let key = config.apiKey, !key.isEmpty { args.append(contentsOf: ["--api-key", key]) }
 
         transition(.starting(detail: "Launching engine"))

--- a/apps/MacApp/Sources/AppCore/ServerSupervisor.swift
+++ b/apps/MacApp/Sources/AppCore/ServerSupervisor.swift
@@ -15,6 +15,8 @@ public struct ServerConfig: Equatable, Sendable {
     public var model: String?
     public var mode: String
     public var maxDraft: String?
+    /// Context cap; nil uses the model's own maximum.
+    public var contextWindow: Int?
     public var host: String
     public var apiKey: String?
     /// Fixed engine port (issue #16) so external OpenAI/Anthropic clients keep a stable
@@ -31,11 +33,13 @@ public struct ServerConfig: Equatable, Sendable {
     public var modelDirs: [String]
 
     public init(model: String? = nil, mode: String = "auto", maxDraft: String? = "auto",
+                contextWindow: Int? = nil,
                 host: String = "127.0.0.1", apiKey: String? = nil, port: Int = 0,
                 portIsExplicit: Bool = true, modelDirs: [String] = []) {
         self.model = model
         self.mode = mode
         self.maxDraft = maxDraft
+        self.contextWindow = contextWindow
         self.host = host
         self.apiKey = apiKey
         self.port = port
@@ -133,6 +137,9 @@ public actor ServerSupervisor {
         if let model = config.model { args.append(contentsOf: ["--model", model]) }
         else { args.append("--no-model") }
         if let maxDraft = config.maxDraft { args.append(contentsOf: ["--max-draft", maxDraft]) }
+        if let contextWindow = config.contextWindow {
+            args.append(contentsOf: ["--context-window", String(contextWindow)])
+        }
         if let key = config.apiKey, !key.isEmpty { args.append(contentsOf: ["--api-key", key]) }
 
         transition(.starting(detail: "Launching engine"))

--- a/apps/MacApp/Sources/AppCore/Telemetry.swift
+++ b/apps/MacApp/Sources/AppCore/Telemetry.swift
@@ -34,6 +34,20 @@ public struct RoundEvent: Decodable, Sendable, Identifiable, Equatable {
     public var isPlainStep: Bool { drafted == 0 }
 }
 
+/// Prompt tokens made ready before decoding, including any prefix-cache reuse.
+public struct PrefillEvent: Decodable, Sendable, Equatable {
+    public let req: String
+    public let mode: String
+    public let processed: Int
+    public let total: Int
+    public let active: Bool
+
+    public var fraction: Double {
+        guard total > 0 else { return 0 }
+        return min(max(Double(processed) / Double(total), 0), 1)
+    }
+}
+
 /// Aggregates over every round the engine has run.
 public struct RoundStats: Decodable, Sendable, Equatable {
     public let rounds: Int
@@ -64,9 +78,10 @@ public struct RoundStats: Decodable, Sendable, Equatable {
     }
 }
 
-/// An event off the `/events` stream: either a round or a periodic aggregate refresh.
+/// A live event off the engine-wide `/events` stream.
 public enum TelemetryEvent: Sendable {
     case round(RoundEvent)
+    case prefill(PrefillEvent)
     case stats(RoundStats)
 }
 

--- a/apps/MacApp/Sources/AppHost/AppModel.swift
+++ b/apps/MacApp/Sources/AppHost/AppModel.swift
@@ -456,6 +456,7 @@ final class AppModel: ObservableObject {
         do {
             let port = try await supervisor.start(
                 config: ServerConfig(model: nil, mode: "auto", maxDraft: "auto",
+                                     contextWindow: Defaults.contextWindow,
                                      host: Defaults.engineHost, apiKey: Defaults.effectiveAPIKey,
                                      port: Defaults.enginePort,
                                      portIsExplicit: Defaults.enginePortIsExplicit,
@@ -472,6 +473,7 @@ final class AppModel: ObservableObject {
             do {
                 let port = try await supervisor.start(
                     config: ServerConfig(model: model, mode: "auto", maxDraft: "auto",
+                                         contextWindow: Defaults.contextWindow,
                                          host: Defaults.engineHost, apiKey: Defaults.effectiveAPIKey,
                                          port: Defaults.enginePort,
                                          portIsExplicit: Defaults.enginePortIsExplicit,
@@ -658,6 +660,9 @@ final class AppModel: ObservableObject {
                                            kvBits: kvBits,
                                            cpuPrefill: cpuPrefill,
                                            enableThinking: enableThinking)
+            if let contextWindow {
+                Defaults.contextWindow = contextWindow == 0 ? nil : contextWindow
+            }
             currentHealth = try? await client.health()
             startTelemetry()
             startMemoryPolling()
@@ -1188,6 +1193,19 @@ enum Defaults {
     static var selectedModel: String? {
         get { store.string(forKey: "selectedModel") }
         set { store.set(newValue, forKey: "selectedModel") }
+    }
+
+    /// Persistent context cap. Nil means use the model's own maximum.
+    static var contextWindow: Int? {
+        get {
+            guard store.object(forKey: "contextWindow") != nil else { return nil }
+            let value = store.integer(forKey: "contextWindow")
+            return value >= 1024 ? value : nil
+        }
+        set {
+            if let newValue { store.set(newValue, forKey: "contextWindow") }
+            else { store.removeObject(forKey: "contextWindow") }
+        }
     }
 
     /// The out-of-the-box engine port. Fixed BY DEFAULT (community ask: agent configs —

--- a/apps/MacApp/Sources/AppHost/AppModel.swift
+++ b/apps/MacApp/Sources/AppHost/AppModel.swift
@@ -130,6 +130,7 @@ final class AppModel: ObservableObject {
 
     // MARK: Telemetry (Lab)
     @Published var rounds: [RoundEvent] = []
+    @Published var prefillProgress: PrefillEvent?
     @Published var stats: RoundStats?
     @Published var calibration: Calibration?
     /// MLX allocator state — what the loaded model holds resident, polled from `/metrics`.
@@ -501,6 +502,7 @@ final class AppModel: ObservableObject {
     func loadModel(_ target: String) async -> Bool {
         guard let client = apiClient else { return false }
         generationTask?.cancel()
+        prefillProgress = nil
         modelSwitchError = nil
         isModelLoading = true
         self.model = target
@@ -611,6 +613,7 @@ final class AppModel: ObservableObject {
     func unloadModel() async {
         guard let client = apiClient, isServerReady else { return }
         generationTask?.cancel()
+        prefillProgress = nil
         rounds = []
         stats = nil
         calibration = nil
@@ -631,6 +634,7 @@ final class AppModel: ObservableObject {
                              kvBits: Int? = nil, enableThinking: Bool? = nil) async {
         guard let client = apiClient else { return }
         generationTask?.cancel()
+        prefillProgress = nil
         modelSwitchError = nil
         rounds = []
         stats = nil
@@ -690,6 +694,7 @@ final class AppModel: ObservableObject {
     /// so the Lab keeps updating even when the tokens are being generated for Claude Code or
     /// any other client pointed at this server.
     private func startTelemetry() {
+        prefillProgress = nil
         // No model → /events answers 503; don't spin against it. The next successful load
         // calls this again.
         guard let client, isServerReady else { return }
@@ -701,12 +706,17 @@ final class AppModel: ObservableObject {
                         guard let self else { return }
                         switch event {
                         case .round(let round):
+                            if self.prefillProgress?.req == round.req {
+                                self.prefillProgress = nil
+                            }
                             self.rounds.append(round)
                             if self.rounds.count > self.liveWindow {
                                 self.rounds.removeFirst(self.rounds.count - self.liveWindow)
                             }
                             if round.ms > 0 { self.observeRate(round.tokensPerSecond) }
                             self.lastActivity = Date()
+                        case .prefill(let progress):
+                            self.prefillProgress = progress.active ? progress : nil
                         case .stats(let stats):
                             self.stats = stats
                         }
@@ -715,6 +725,7 @@ final class AppModel: ObservableObject {
                     // The stream ends when the engine restarts or a socket drops; reconnect
                     // rather than leaving the Lab silently frozen.
                 }
+                self?.prefillProgress = nil
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }

--- a/apps/MacApp/Sources/AppHost/AppModel.swift
+++ b/apps/MacApp/Sources/AppHost/AppModel.swift
@@ -83,6 +83,40 @@ struct ChatSettings: Codable, Equatable {
     var reasoningEffort: String?
 }
 
+/// Engine settings belonging to one model target. Optional fields stay optional so an older
+/// engine keeps its pair default when it does not expose that control.
+struct ModelSettings: Codable, Equatable {
+    var mode: String = "auto"
+    var maxDraft: String = "auto"
+    var confidenceThreshold: Double = 0.0
+    var contextWindow: Int?
+    var lookupDrafts: Bool?
+    var kvBits: Int?
+    var cpuPrefill: Bool?
+    var enableThinking: Bool?
+
+    init(mode: String = "auto", maxDraft: String = "auto", confidenceThreshold: Double = 0.0,
+         contextWindow: Int? = nil, lookupDrafts: Bool? = nil, kvBits: Int? = nil,
+         cpuPrefill: Bool? = nil, enableThinking: Bool? = nil) {
+        self.mode = mode
+        self.maxDraft = maxDraft
+        self.confidenceThreshold = confidenceThreshold
+        self.contextWindow = contextWindow
+        self.lookupDrafts = lookupDrafts
+        self.kvBits = kvBits
+        self.cpuPrefill = cpuPrefill
+        self.enableThinking = enableThinking
+    }
+
+    init(health: HealthInfo) {
+        self.init(mode: health.mode ?? "auto", maxDraft: health.maxDraft ?? "auto",
+                  confidenceThreshold: health.confidenceThreshold ?? 0.0,
+                  contextWindow: health.contextWindow, lookupDrafts: health.lookupDrafts,
+                  kvBits: health.kvBits, cpuPrefill: health.cpuSplit != nil,
+                  enableThinking: health.thinkingDefault.map { $0 == "on" })
+    }
+}
+
 /// A log line with a stable identity, so trimming the buffer never reshuffles SwiftUI ids.
 struct LogRow: Identifiable {
     let id: Int
@@ -329,10 +363,11 @@ final class AppModel: ObservableObject {
     /// boot on a return visit. The server itself starts model-less (`--no-model`, seconds) and
     /// the window opens immediately; the model then loads *inside* the running window with
     /// inline progress, instead of gating the whole app behind a loading screen.
-    func startServer(model: String) async {
+    func startServer(model: String, preserving settings: ModelSettings? = nil) async {
         self.model = model
         Defaults.selectedModel = model
-        guard await spawnServer() else { return }
+        let settings = settings ?? Defaults.modelSettings(for: model)
+        guard await spawnServer(preserving: settings) else { return }
         phase = .ready
         await refreshDiagnostics()               // model pickers work before anything loads
         let loaded: Bool
@@ -342,7 +377,7 @@ final class AppModel: ObservableObject {
             startMemoryPolling()
             loaded = true
         } else {
-            loaded = await loadModel(model)
+            loaded = await loadModel(model, applying: settings)
         }
         if loaded, isFirstRun {
             // The plan's "hooked" moment: straight from onboarding into a race the user
@@ -420,8 +455,12 @@ final class AppModel: ObservableObject {
     /// fixed port (Settings → Local server) or model folder takes effect without relaunching
     /// the app. The model reloads through the same path a launch uses.
     func restartEngine() async {
+        guard !isModelLoading else { return }
+        let activeSettings = Defaults.modelSettings(for: model)
+            ?? currentHealth.map(ModelSettings.init)
+        logStore.note("restarting engine")
         await supervisor?.stop()
-        await startServer(model: model)
+        await startServer(model: model, preserving: activeSettings)
     }
 
     /// Apply a pending engine update NOW instead of on the next launch (issue #16: a stuck
@@ -445,7 +484,7 @@ final class AppModel: ObservableObject {
 
     /// Spawn `mlx-dspark serve --no-model` and wait for `/health` — up in seconds (python
     /// import, no weights). Returns false after calling `fail()` when even that can't start.
-    private func spawnServer() async -> Bool {
+    private func spawnServer(preserving settings: ModelSettings? = nil) async -> Bool {
         guard let engine = engineURL else { return false }
         phase = .startingServer
         let supervisor = ServerSupervisor(engine: engine, logStore: logStore)
@@ -453,14 +492,19 @@ final class AppModel: ObservableObject {
         await supervisor.observeState { [weak self] state in
             Task { @MainActor in self?.serverState = state }
         }
+        let config = ServerConfig(model: nil, mode: settings?.mode ?? "auto",
+                                  maxDraft: settings?.maxDraft ?? "auto",
+                                  contextWindow: settings?.contextWindow,
+                                  host: Defaults.engineHost, apiKey: Defaults.effectiveAPIKey,
+                                  port: Defaults.enginePort,
+                                  portIsExplicit: Defaults.enginePortIsExplicit,
+                                  modelDirs: modelDirs,
+                                  confidenceThreshold: settings?.confidenceThreshold ?? 0.0,
+                                  lookupDrafts: settings?.lookupDrafts,
+                                  kvBits: settings?.kvBits,
+                                  enableThinking: settings?.enableThinking)
         do {
-            let port = try await supervisor.start(
-                config: ServerConfig(model: nil, mode: "auto", maxDraft: "auto",
-                                     contextWindow: Defaults.contextWindow,
-                                     host: Defaults.engineHost, apiKey: Defaults.effectiveAPIKey,
-                                     port: Defaults.enginePort,
-                                     portIsExplicit: Defaults.enginePortIsExplicit,
-                                     modelDirs: modelDirs))
+            let port = try await supervisor.start(config: config)
             return await connect(port: port)
         } catch {
             // An engine below this app's floor doesn't know `--no-model`, and an offline
@@ -471,13 +515,9 @@ final class AppModel: ObservableObject {
             logStore.note("model-less start failed — retrying with the model inline "
                           + "(older engine?)")
             do {
-                let port = try await supervisor.start(
-                    config: ServerConfig(model: model, mode: "auto", maxDraft: "auto",
-                                         contextWindow: Defaults.contextWindow,
-                                         host: Defaults.engineHost, apiKey: Defaults.effectiveAPIKey,
-                                         port: Defaults.enginePort,
-                                         portIsExplicit: Defaults.enginePortIsExplicit,
-                                         modelDirs: modelDirs))
+                var inlineConfig = config
+                inlineConfig.model = model
+                let port = try await supervisor.start(config: inlineConfig)
                 return await connect(port: port)
             } catch {
                 fail(error)
@@ -501,8 +541,9 @@ final class AppModel: ObservableObject {
     /// Load `target` into the running server (`/admin/load`) with inline progress — the
     /// window, the port, and every other screen stay up throughout. Returns whether it loaded.
     @discardableResult
-    func loadModel(_ target: String) async -> Bool {
+    func loadModel(_ target: String, applying settings: ModelSettings? = nil) async -> Bool {
         guard let client = apiClient else { return false }
+        let profile = settings ?? Defaults.modelSettings(for: target)
         generationTask?.cancel()
         prefillProgress = nil
         modelSwitchError = nil
@@ -536,7 +577,18 @@ final class AppModel: ObservableObject {
             isCancellingLoad = false
         }
         do {
-            _ = try await client.loadModel(target)
+            // Context is sticky in the running engine, so 0 is required when a model has no
+            // saved cap; it means "use this model's own maximum" and prevents leakage.
+            _ = try await client.loadModel(
+                target,
+                mode: profile?.mode,
+                maxDraft: profile?.maxDraft,
+                confidence: profile.map { $0.confidenceThreshold },
+                contextWindow: profile.map { $0.contextWindow ?? 0 } ?? 0,
+                lookupDrafts: profile?.lookupDrafts,
+                kvBits: profile?.kvBits,
+                cpuPrefill: profile?.cpuPrefill ?? (profile == nil ? false : nil),
+                enableThinking: profile?.enableThinking ?? (profile == nil ? true : nil))
             // Re-point health at the new model and restart the telemetry stream (the old one
             // ended when the engine it was streaming from was torn down).
             currentHealth = try? await client.health()
@@ -643,14 +695,39 @@ final class AppModel: ObservableObject {
         stats = nil
         calibration = nil
         loadingDetail = "Applying mode \(mode ?? "auto") · cap \(cap ?? "auto") — reloading "
-            + "the model in place. Weights are already on disk; this takes seconds to a "
-            + "minute, and the server's port stays up."
+            + "the model in place. The first DSpark load may download a drafter and calibrate "
+            + "this Mac; the server's port stays up."
         isModelLoading = true
         logStore.note("reloading \(model) — mode \(mode ?? "auto") · cap \(cap ?? "auto")"
                       + (confidence.map { " · conf \($0)" } ?? ""))
+        let previousSettings = Defaults.modelSettings(for: model)
+            ?? currentHealth.map(ModelSettings.init)
+        let nextSettings = ModelSettings(
+            mode: mode ?? previousSettings?.mode ?? "auto",
+            maxDraft: cap ?? previousSettings?.maxDraft ?? "auto",
+            confidenceThreshold: confidence ?? previousSettings?.confidenceThreshold ?? 0.0,
+            contextWindow: contextWindow.map { $0 == 0 ? nil : $0 }
+                ?? previousSettings?.contextWindow,
+            lookupDrafts: lookupDrafts ?? previousSettings?.lookupDrafts,
+            kvBits: kvBits ?? previousSettings?.kvBits,
+            cpuPrefill: cpuPrefill ?? previousSettings?.cpuPrefill,
+            enableThinking: enableThinking ?? previousSettings?.enableThinking)
+        let poll = Task { [weak self] in
+            while !Task.isCancelled {
+                let health = try? await client.health()
+                await MainActor.run {
+                    self?.downloadProgress = health?.download
+                    self?.loadPhase = health?.phase
+                }
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
         defer {
+            poll.cancel()
             isModelLoading = false
             loadingDetail = nil
+            downloadProgress = nil
+            loadPhase = nil
         }
         do {
             _ = try await client.loadModel(model, mode: mode, maxDraft: cap,
@@ -660,18 +737,27 @@ final class AppModel: ObservableObject {
                                            kvBits: kvBits,
                                            cpuPrefill: cpuPrefill,
                                            enableThinking: enableThinking)
-            if let contextWindow {
-                Defaults.contextWindow = contextWindow == 0 ? nil : contextWindow
-            }
+            Defaults.saveModelSettings(nextSettings, for: model)
             currentHealth = try? await client.health()
             startTelemetry()
             startMemoryPolling()
             await refreshDiagnostics()
         } catch {
             modelSwitchError = error.localizedDescription
-            // The engine is modelless after a failed load — restore with default settings.
+            // The engine is modelless after a failed load — restore the previous profile.
             // If even that fails, the server survives model-less; the picker still works.
-            _ = try? await client.loadModel(model)
+            _ = try? await client.loadModel(
+                model,
+                mode: previousSettings?.mode,
+                maxDraft: previousSettings?.maxDraft,
+                confidence: previousSettings.map { $0.confidenceThreshold },
+                contextWindow: previousSettings.map { $0.contextWindow ?? 0 } ?? 0,
+                lookupDrafts: previousSettings?.lookupDrafts,
+                kvBits: previousSettings?.kvBits,
+                cpuPrefill: previousSettings?.cpuPrefill ?? (previousSettings == nil
+                    ? false : nil),
+                enableThinking: previousSettings?.enableThinking ?? (previousSettings == nil
+                    ? true : nil))
             currentHealth = try? await client.health()
             startTelemetry()
             startMemoryPolling()
@@ -1156,6 +1242,7 @@ final class AppModel: ObservableObject {
 /// how the app gets driven for screenshots and QA without a click.
 enum Defaults {
     private static let store = UserDefaults.standard
+    private static let modelSettingsPrefix = "modelSettings."
 
     static var screen: Screen {
         get { store.string(forKey: "screen").flatMap(Screen.init(rawValue:)) ?? .chat }
@@ -1195,17 +1282,33 @@ enum Defaults {
         set { store.set(newValue, forKey: "selectedModel") }
     }
 
-    /// Persistent context cap. Nil means use the model's own maximum.
-    static var contextWindow: Int? {
-        get {
-            guard store.object(forKey: "contextWindow") != nil else { return nil }
-            let value = store.integer(forKey: "contextWindow")
-            return value >= 1024 ? value : nil
+    /// Settings are keyed by the exact model target, so changing one model never changes
+    /// another model's mode, cap, context, or auxiliary decode knobs.
+    static func modelSettings(for model: String) -> ModelSettings? {
+        let key = modelSettingsPrefix + model
+        if let data = store.data(forKey: key),
+           let settings = try? JSONDecoder().decode(ModelSettings.self, from: data) {
+            return settings
         }
-        set {
-            if let newValue { store.set(newValue, forKey: "contextWindow") }
-            else { store.removeObject(forKey: "contextWindow") }
-        }
+
+        // Migrate the old global context cap once, and only to the model it belonged to.
+        guard model == selectedModel,
+              let value = legacyContextWindow else { return nil }
+        let settings = ModelSettings(contextWindow: value)
+        saveModelSettings(settings, for: model)
+        store.removeObject(forKey: "contextWindow")
+        return settings
+    }
+
+    static func saveModelSettings(_ settings: ModelSettings, for model: String) {
+        guard let data = try? JSONEncoder().encode(settings) else { return }
+        store.set(data, forKey: modelSettingsPrefix + model)
+    }
+
+    private static var legacyContextWindow: Int? {
+        guard store.object(forKey: "contextWindow") != nil else { return nil }
+        let value = store.integer(forKey: "contextWindow")
+        return value >= 1024 ? value : nil
     }
 
     /// The out-of-the-box engine port. Fixed BY DEFAULT (community ask: agent configs —

--- a/apps/MacApp/Sources/AppHost/AppModel.swift
+++ b/apps/MacApp/Sources/AppHost/AppModel.swift
@@ -631,7 +631,8 @@ final class AppModel: ObservableObject {
     /// speed changes.
     func applyEngineSettings(mode: String?, cap: String?, confidence: Double? = nil,
                              contextWindow: Int? = nil, lookupDrafts: Bool? = nil,
-                             kvBits: Int? = nil, enableThinking: Bool? = nil) async {
+                             kvBits: Int? = nil, cpuPrefill: Bool? = nil,
+                             enableThinking: Bool? = nil) async {
         guard let client = apiClient else { return }
         generationTask?.cancel()
         prefillProgress = nil
@@ -655,6 +656,7 @@ final class AppModel: ObservableObject {
                                            contextWindow: contextWindow,
                                            lookupDrafts: lookupDrafts,
                                            kvBits: kvBits,
+                                           cpuPrefill: cpuPrefill,
                                            enableThinking: enableThinking)
             currentHealth = try? await client.health()
             startTelemetry()

--- a/apps/MacApp/Sources/AppHost/ChatScreen.swift
+++ b/apps/MacApp/Sources/AppHost/ChatScreen.swift
@@ -176,7 +176,7 @@ struct ChatSettingsPanel: View {
                         Slider(value: Binding(
                             get: { temperature },
                             set: { model.chatSettings.temperature = $0 }
-                        ), in: 0...1.5)
+                        ), in: 0...1.5, step: 0.01)
                         Text(String(format: "%.2f", temperature))
                             .font(.caption.monospacedDigit()).frame(width: 34)
                     }
@@ -198,7 +198,7 @@ struct ChatSettingsPanel: View {
                         Slider(value: Binding(
                             get: { topP },
                             set: { model.chatSettings.topP = $0 }
-                        ), in: 0.05...1.0)
+                        ), in: 0.05...1.0, step: 0.01)
                         Text(String(format: "%.2f", topP))
                             .font(.caption.monospacedDigit()).frame(width: 34)
                     }

--- a/apps/MacApp/Sources/AppHost/RootView.swift
+++ b/apps/MacApp/Sources/AppHost/RootView.swift
@@ -386,7 +386,18 @@ struct StatusBar: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            if let pairing = model.pairingLine {
+            if let progress = model.prefillProgress {
+                ProgressView(value: progress.fraction)
+                    .progressViewStyle(.linear)
+                    .tint(Theme.spark)
+                    .frame(width: 72)
+                    .accessibilityLabel("Prefill progress")
+                    .accessibilityValue("\(Int(progress.fraction * 100)) percent")
+                Text("Prefill \(progress.processed.formatted()) / "
+                     + "\(progress.total.formatted()) · \(Int(progress.fraction * 100))%")
+                    .font(.caption.monospacedDigit())
+                    .lineLimit(1).truncationMode(.middle)
+            } else if let pairing = model.pairingLine {
                 Image(systemName: "arrow.triangle.merge").imageScale(.small)
                 Text(pairing).font(.caption.monospaced())
                     .lineLimit(1).truncationMode(.middle)

--- a/apps/MacApp/Sources/AppHost/SettingsScreen.swift
+++ b/apps/MacApp/Sources/AppHost/SettingsScreen.swift
@@ -176,9 +176,28 @@ struct DecodingControls: View {
         return String(format: "%.1f", value)
     }
 
+    private var healthForModel: HealthInfo? {
+        guard model.health?.target == model.model else { return nil }
+        return model.health
+    }
+
+    private func syncFromModel() {
+        let saved = Defaults.modelSettings(for: model.model)
+        let health = healthForModel
+        mode = saved?.mode ?? health?.mode ?? "auto"
+        cap = saved?.maxDraft ?? health?.maxDraft ?? "auto"
+        confidence = Self.confTag(saved?.confidenceThreshold ?? health?.confidenceThreshold)
+        contextWindow = Self.contextTag(saved?.contextWindow ?? health?.contextWindow)
+        lookupDrafts = saved?.lookupDrafts ?? health?.lookupDrafts ?? true
+        kvBits = Self.kvTag(saved?.kvBits ?? health?.kvBits)
+        cpuPrefill = saved?.cpuPrefill ?? (health?.cpuSplit != nil)
+        apiThinking = saved?.enableThinking.map { $0 ? "on" : "off" }
+            ?? health?.thinkingDefault ?? "on"
+    }
+
     private var confOptions: [String] {
         var options = ["off", "0.2", "0.3", "0.5"]
-        let current = Self.confTag(model.health?.confidenceThreshold)
+        let current = Self.confTag(healthForModel?.confidenceThreshold)
         if !options.contains(current) { options.append(current) }
         return options
     }
@@ -213,19 +232,19 @@ struct DecodingControls: View {
                         contextPicker
                         Spacer(minLength: 0)
                     }
-                    if model.health?.kvBits != nil {
+                    if healthForModel?.kvBits != nil {
                         HStack(spacing: 14) {
                             kvPicker
                             Spacer(minLength: 0)
                         }
                     }
-                    if model.health?.lookupDrafts != nil {
+                    if healthForModel?.lookupDrafts != nil {
                         HStack(spacing: 14) {
                             lookupToggle
                             Spacer(minLength: 0)
                         }
                     }
-                    if model.health?.thinkingDefault != nil {
+                    if healthForModel?.thinkingDefault != nil {
                         HStack(spacing: 14) {
                             apiThinkingPicker
                             Spacer(minLength: 0)
@@ -253,13 +272,13 @@ struct DecodingControls: View {
                     }
                     HStack(spacing: 14) {
                         contextPicker
-                        if model.health?.kvBits != nil {
+                        if healthForModel?.kvBits != nil {
                             kvPicker
                         }
-                        if model.health?.lookupDrafts != nil {
+                        if healthForModel?.lookupDrafts != nil {
                             lookupToggle
                         }
-                        if model.health?.thinkingDefault != nil {
+                        if healthForModel?.thinkingDefault != nil {
                             apiThinkingPicker
                         }
                         applyControl
@@ -275,16 +294,8 @@ struct DecodingControls: View {
         // The pickers show what the engine is actually running, not a stale default — the
         // server reports both (`/health` mode + max_draft), so a reopened popover agrees
         // with what was applied.
-        .onAppear {
-            mode = model.health?.mode ?? "auto"
-            cap = model.health?.maxDraft ?? "auto"
-            confidence = Self.confTag(model.health?.confidenceThreshold)
-            contextWindow = Self.contextTag(model.health?.contextWindow)
-            lookupDrafts = model.health?.lookupDrafts ?? true
-            kvBits = Self.kvTag(model.health?.kvBits)
-            cpuPrefill = model.health?.cpuSplit != nil
-            apiThinking = model.health?.thinkingDefault ?? "on"
-        }
+        .onAppear { syncFromModel() }
+        .onChange(of: model.model) { _, _ in syncFromModel() }
     }
 
     /// The engine's thinking default for *API* requests that don't say (issue #19): the
@@ -373,9 +384,9 @@ struct DecodingControls: View {
     @ViewBuilder private var cpuPrefillToggle: some View {
         Toggle("CPU prefill (experimental)", isOn: $cpuPrefill)
             .fixedSize()
-            .help("Speeds up long uncached prompts by using CPU and GPU together. "
-                  + "Does not affect decode speed. May crash MLX on some Macs. "
-                  + "Off again after restarting the app.")
+        .help("Speeds up long uncached prompts by using CPU and GPU together. "
+              + "Does not affect decode speed. May crash MLX on some Macs. "
+              + "Stored separately for each model.")
     }
 
     @ViewBuilder private var applyControl: some View {
@@ -388,13 +399,17 @@ struct DecodingControls: View {
     }
 
     private var isDirty: Bool {
-        mode != (model.health?.mode ?? "auto") || cap != (model.health?.maxDraft ?? "auto")
-            || confidence != Self.confTag(model.health?.confidenceThreshold)
-            || contextWindow != Self.contextTag(model.health?.contextWindow)
-            || lookupDrafts != (model.health?.lookupDrafts ?? lookupDrafts)
-            || kvBits != Self.kvTag(model.health?.kvBits)
-            || cpuPrefill != (model.health?.cpuSplit != nil)
-            || apiThinking != (model.health?.thinkingDefault ?? apiThinking)
+        let saved = Defaults.modelSettings(for: model.model)
+        let health = healthForModel
+        let baseline = saved ?? health.map(ModelSettings.init) ?? ModelSettings()
+        return mode != baseline.mode || cap != baseline.maxDraft
+            || confidence != Self.confTag(baseline.confidenceThreshold)
+            || contextWindow != Self.contextTag(baseline.contextWindow)
+            || lookupDrafts != (baseline.lookupDrafts ?? lookupDrafts)
+            || kvBits != Self.kvTag(baseline.kvBits)
+            || cpuPrefill != (baseline.cpuPrefill ?? (health?.cpuSplit != nil))
+            || apiThinking != (baseline.enableThinking.map { $0 ? "on" : "off" }
+                ?? health?.thinkingDefault ?? apiThinking)
     }
 
     private func apply() {
@@ -406,14 +421,14 @@ struct DecodingControls: View {
                 contextWindow: contextWindow == "default" ? 0 : Int(contextWindow),
                 // Sent only when the user actually flipped it, so an untouched Apply
                 // keeps riding the pair's measured default instead of pinning it.
-                lookupDrafts: lookupDrafts == model.health?.lookupDrafts ? nil : lookupDrafts,
+                lookupDrafts: lookupDrafts == healthForModel?.lookupDrafts ? nil : lookupDrafts,
                 // Same: unchanged -> nil (keep the server's setting); "default" -> explicit
                 // 0 (full precision). Gated on health reporting the field at all.
-                kvBits: kvBits == Self.kvTag(model.health?.kvBits) ? nil
+                kvBits: kvBits == Self.kvTag(healthForModel?.kvBits) ? nil
                         : (kvBits == "default" ? 0 : Int(kvBits)),
-                cpuPrefill: cpuPrefill == (model.health?.cpuSplit != nil) ? nil : cpuPrefill,
+                cpuPrefill: cpuPrefill == (healthForModel?.cpuSplit != nil) ? nil : cpuPrefill,
                 // Unchanged -> nil (keep); "on" -> true = the model's own default.
-                enableThinking: apiThinking == model.health?.thinkingDefault ? nil
+                enableThinking: apiThinking == healthForModel?.thinkingDefault ? nil
                         : (apiThinking == "on"))
             applying = false
         }
@@ -619,7 +634,7 @@ struct ServerCard: View {
                 Task { await model.restartEngine(); restarting = false }
             }
             .font(.caption)
-            .disabled(restarting)
+            .disabled(restarting || model.isModelLoading)
             Spacer()
         }
         Text("A fixed port keeps external clients' base URL stable across launches "

--- a/apps/MacApp/Sources/AppHost/SettingsScreen.swift
+++ b/apps/MacApp/Sources/AppHost/SettingsScreen.swift
@@ -403,7 +403,7 @@ struct DecodingControls: View {
             await model.applyEngineSettings(
                 mode: mode, cap: cap,
                 confidence: confidence == "off" ? 0.0 : Double(confidence),
-                contextWindow: contextWindow == "default" ? nil : Int(contextWindow),
+                contextWindow: contextWindow == "default" ? 0 : Int(contextWindow),
                 // Sent only when the user actually flipped it, so an untouched Apply
                 // keeps riding the pair's measured default instead of pinning it.
                 lookupDrafts: lookupDrafts == model.health?.lookupDrafts ? nil : lookupDrafts,

--- a/apps/MacApp/Sources/AppHost/SettingsScreen.swift
+++ b/apps/MacApp/Sources/AppHost/SettingsScreen.swift
@@ -144,6 +144,7 @@ struct DecodingControls: View {
     @State private var contextWindow: String = "default"
     @State private var lookupDrafts: Bool = true
     @State private var kvBits: String = "default"
+    @State private var cpuPrefill = false
     /// "on" / "off" — the engine's thinking default for API requests that don't specify it.
     @State private var apiThinking: String = "on"
     @State private var applying = false
@@ -230,6 +231,10 @@ struct DecodingControls: View {
                             Spacer(minLength: 0)
                         }
                     }
+                    HStack(spacing: 14) {
+                        cpuPrefillToggle
+                        Spacer(minLength: 0)
+                    }
                     HStack(spacing: 8) {
                         applyControl
                         if !applying, isDirty {
@@ -260,6 +265,10 @@ struct DecodingControls: View {
                         applyControl
                         Spacer(minLength: 0)
                     }
+                    HStack(spacing: 14) {
+                        cpuPrefillToggle
+                        Spacer(minLength: 0)
+                    }
                 }
             }
         }
@@ -273,6 +282,7 @@ struct DecodingControls: View {
             contextWindow = Self.contextTag(model.health?.contextWindow)
             lookupDrafts = model.health?.lookupDrafts ?? true
             kvBits = Self.kvTag(model.health?.kvBits)
+            cpuPrefill = model.health?.cpuSplit != nil
             apiThinking = model.health?.thinkingDefault ?? "on"
         }
     }
@@ -360,6 +370,14 @@ struct DecodingControls: View {
                   + "Flip it to A/B on your own content; it can't affect output, only speed.")
     }
 
+    @ViewBuilder private var cpuPrefillToggle: some View {
+        Toggle("CPU prefill (experimental)", isOn: $cpuPrefill)
+            .fixedSize()
+            .help("Speeds up long uncached prompts by using CPU and GPU together. "
+                  + "Does not affect decode speed. May crash MLX on some Macs. "
+                  + "Off again after restarting the app.")
+    }
+
     @ViewBuilder private var applyControl: some View {
         if applying {
             ProgressView().controlSize(.small)
@@ -375,6 +393,7 @@ struct DecodingControls: View {
             || contextWindow != Self.contextTag(model.health?.contextWindow)
             || lookupDrafts != (model.health?.lookupDrafts ?? lookupDrafts)
             || kvBits != Self.kvTag(model.health?.kvBits)
+            || cpuPrefill != (model.health?.cpuSplit != nil)
             || apiThinking != (model.health?.thinkingDefault ?? apiThinking)
     }
 
@@ -392,6 +411,7 @@ struct DecodingControls: View {
                 // 0 (full precision). Gated on health reporting the field at all.
                 kvBits: kvBits == Self.kvTag(model.health?.kvBits) ? nil
                         : (kvBits == "default" ? 0 : Int(kvBits)),
+                cpuPrefill: cpuPrefill == (model.health?.cpuSplit != nil) ? nil : cpuPrefill,
                 // Unchanged -> nil (keep); "on" -> true = the model's own default.
                 enableThinking: apiThinking == model.health?.thinkingDefault ? nil
                         : (apiThinking == "on"))

--- a/apps/MacApp/Tests/AppCoreTests/AppCoreTests.swift
+++ b/apps/MacApp/Tests/AppCoreTests/AppCoreTests.swift
@@ -155,6 +155,24 @@ struct SpecInfoTests {
     }
 }
 
+@Suite("Prefill telemetry")
+struct PrefillEventTests {
+    @Test func decodesProgressAndBoundsItsFraction() throws {
+        let json = """
+        {"req":"abc","mode":"dflash","processed":16384,"total":21935,"active":true}
+        """
+        let progress = try JSONDecoder().decode(PrefillEvent.self, from: Data(json.utf8))
+        #expect(progress.req == "abc" && progress.mode == "dflash" && progress.active)
+        #expect(abs(progress.fraction - 16384.0 / 21935.0) < 0.0001)
+
+        let over = """
+        {"req":"abc","mode":"dflash","processed":12,"total":10,"active":false}
+        """
+        #expect(try JSONDecoder().decode(PrefillEvent.self,
+                                         from: Data(over.utf8)).fraction == 1)
+    }
+}
+
 @Suite("Health payload")
 struct HealthInfoTests {
     /// Verbatim from a live `mlx-dspark serve` on 2026-07-21 — decoding must not drift from

--- a/apps/MacApp/Tests/AppCoreTests/AppCoreTests.swift
+++ b/apps/MacApp/Tests/AppCoreTests/AppCoreTests.swift
@@ -182,13 +182,15 @@ struct HealthInfoTests {
         {"status": "ok", "model": "Qwen3-4B-8bit", "mode": "dspark",
          "target": "mlx-community/Qwen3-4B-8bit",
          "drafter": "deepseek-ai/dspark_qwen3_4b_block7",
-         "context_window": 40960, "max_output_tokens": 32768}
+         "context_window": 40960, "max_output_tokens": 32768,
+         "cpu_split": {"min_rows": 512, "fracs": {"512": 0.2}}}
         """
         let health = try JSONDecoder().decode(HealthInfo.self, from: Data(json.utf8))
         #expect(health.status == "ok")
         #expect(health.mode == "dspark")
         #expect(health.drafter == "deepseek-ai/dspark_qwen3_4b_block7")
         #expect(health.contextWindow == 40960)
+        #expect(health.cpuSplit?.minRows == 512)
     }
 
     /// Drafter-free modes (lookup, baseline) report no drafter; the UI must not require one.
@@ -197,6 +199,7 @@ struct HealthInfoTests {
         let health = try JSONDecoder().decode(HealthInfo.self, from: Data(json.utf8))
         #expect(health.drafter == nil)
         #expect(health.contextWindow == nil)
+        #expect(health.cpuSplit == nil)
     }
 }
 

--- a/scripts/prefill.py
+++ b/scripts/prefill.py
@@ -7,9 +7,9 @@ prefill->decode boundary (``mx.eval(logits); t_prefill``), so:
 
     prefill tok/s = len(prompt_ids) / result.prefill_seconds
 
-The prefill paths the CLI/server enable (wide-GEMM, CPU co-prefill) are applied the
-same way here, so the numbers match ``mlx-dspark generate``; ``--cpu-split 0`` measures
-the stock-GPU-only arm for an A/B.
+The prefill paths the CLI/server expose (wide-GEMM, CPU co-prefill) are applied the
+same way here, so the numbers match ``mlx-dspark generate``; ``--cpu-split FRAC`` opts
+into the CPU arm for an A/B.
 
 We feed a controlled ``prompt_ids`` of exact length (content is ~irrelevant to prefill
 throughput), warm up first (kernel compile + clock ramp otherwise land in the first
@@ -45,8 +45,7 @@ def main() -> None:
                          "between-trial noise is ~14%% on an M4 Pro)")
     ap.add_argument("--cpu-split", type=float, default=None, metavar="FRAC",
                     help="prefill CPU co-prefill row fraction (see `mlx-dspark generate -h`). "
-                         "Unset = the calibrated default the CLI/server use; 0 = off (the "
-                         "A/B arm); a fraction pins it.")
+                         "Unset/0 = off; a fraction opts in for an A/B.")
     ap.add_argument("--max-new-tokens", type=int, default=8,
                     help="decode length (only used to also report decode tok/s; prefill is "
                          "unaffected). Default 8.")
@@ -69,7 +68,7 @@ def main() -> None:
     print(f"# loaded in {time.time() - t0:.1f}s")
     # The prefill paths exactly as `mlx-dspark serve`/`generate` run them (both are process
     # globals the library leaves off): wide-GEMM (bit-identical, calibrated crossover) and
-    # CPU co-prefill (fp-tie class, calibrated fraction; --cpu-split 0 is the stock arm).
+    # CPU co-prefill (fp-tie class, explicit fraction; unset/0 is the stock arm).
     from mlx_dspark.calibrate import apply_cpu_split, apply_wide_gemm
 
     apply_wide_gemm(target, None, target_repo=target_repo, verbose=False)

--- a/src/mlx_dspark/calibrate.py
+++ b/src/mlx_dspark/calibrate.py
@@ -870,18 +870,19 @@ def cpu_split_config(target, drafter=None, *, target_repo: str,
 
 
 def apply_cpu_split(target, drafter=None, *, target_repo: str,
-                    frac: float | None = None, verbose: bool = True) -> dict | None:
+                    frac: float | str | None = None, verbose: bool = True) -> dict | None:
     """Turn prefill CPU co-prefill on for this process (``generate.CPU_SPLIT``) and
     return the configuration used, or ``None`` when off.
 
-    ``frac=None`` calibrates (and caches); ``0`` disables; a float forces that CPU row
-    fraction from ``wide_gemm.SAFE_MIN_ROWS`` up (an A/B knob, not a tuned default).
+    ``frac=None`` and ``0`` disable it; ``"auto"`` uses the cached machine+model
+    calibration; a float forces that CPU row fraction from ``wide_gemm.SAFE_MIN_ROWS``
+    up (an explicit A/B knob).
     Process-wide global rather than a library default, like the wide path: a plain
     ``speculative_generate`` call must not silently change numerics class."""
     from . import generate as _gen
     from .wide_gemm import SAFE_MIN_ROWS
 
-    if frac is None:
+    if frac == "auto":
         _gen.CPU_SPLIT = cpu_split_config(target, drafter, target_repo=target_repo,
                                           verbose=verbose)
     elif not frac:

--- a/src/mlx_dspark/cli.py
+++ b/src/mlx_dspark/cli.py
@@ -120,8 +120,7 @@ def cmd_generate(argv: list[str]) -> None:
                     help="prefill only: hand this fraction of every wide QuantizedLinear's "
                          "rows to the CPU stream, concurrently with the GPU (the CPU's "
                          "matrix units are a second GEMM engine prefill never used). "
-                         "Default: measure the best fraction per width for this "
-                         "machine+model once and cache it; 0 disables. Not bit-identical "
+                         "Default: off; pass a fraction to opt in. Not bit-identical "
                          "(fp-tie class, like chunked prefill); 1.41x prefill on an M4 Pro "
                          "with Qwen3.8-27B-4bit")
     ap.add_argument("--small-m", action=argparse.BooleanOptionalAction, default=None,
@@ -207,8 +206,8 @@ def cmd_generate(argv: list[str]) -> None:
     from .calibrate import apply_wide_gemm
 
     apply_wide_gemm(target, drafter, target_repo=target_repo, min_rows=args.wide_gemm_min)
-    # prefill CPU co-prefill: a measured fraction of each wide matmul's rows runs on the
-    # CPU stream concurrently with the GPU (see wide_gemm.py)
+    # optional CPU co-prefill: an explicit fraction of each wide matmul's rows runs on
+    # the CPU stream concurrently with the GPU (see wide_gemm.py)
     from .calibrate import apply_cpu_split
 
     apply_cpu_split(target, drafter, target_repo=target_repo, frac=args.cpu_split)
@@ -417,10 +416,10 @@ def cmd_serve(argv: list[str]) -> None:
                          "model_file / auto_map). Refused by default: a crafted model repo "
                          "would run code as you. Also MLX_DSPARK_TRUST_REMOTE_CODE=1")
     ap.add_argument("--cpu-split", type=float, default=None, metavar="FRAC",
-                    help="prefill CPU co-prefill row fraction (default: calibrated once and "
-                         "cached; 0 disables — see `mlx-dspark generate -h`). /health "
+                    help="prefill CPU co-prefill row fraction (default: off; pass a fraction "
+                         "to opt in — see `mlx-dspark generate -h`). /health "
                          "reports the live state; /admin/load takes a per-swap "
-                         "`cpu_split` override (0 = off)")
+                         "`cpu_split` override (`auto`, fraction, or 0 = off)")
     ap.add_argument("--small-m", action=argparse.BooleanOptionalAction, default=None,
                     help="small-M MMA verify kernel (see `mlx-dspark generate --help`). "
                          "Unset = on where the cached probe proves it faster on this machine; "
@@ -488,7 +487,7 @@ def cmd_serve(argv: list[str]) -> None:
         "lookup_long_draft": args.lookup_long_draft,
         "wired_limit": args.wired_limit,
         "wide_gemm_min": args.wide_gemm_min,
-        "cpu_split": args.cpu_split,             # None = calibrated default, 0 = off
+        "cpu_split": args.cpu_split,             # None/0 = off, fraction = explicit opt-in
         "small_m": args.small_m,                 # None = probe-gated default, False = off
         "sdpa_split": args.sdpa_split,            # None = probe-gated default, False = off
         "warmup": args.warmup,                   # warm the kernels on load (first request fast)
@@ -704,7 +703,7 @@ def cmd_benchmark(argv: list[str]) -> None:
                          "would run code as you. Also MLX_DSPARK_TRUST_REMOTE_CODE=1")
     ap.add_argument("--cpu-split", type=float, default=None, metavar="FRAC",
                     help="prefill CPU co-prefill row fraction (see `mlx-dspark generate -h`). "
-                         "Unset = calibrated default; 0 forces it off for an A/B. Prints "
+                         "Unset/0 = off; a fraction opts in for an A/B. Prints "
                          "in the header (it moves the prefill column, not decode).")
     ap.add_argument("--json", default=None, help="also write results to this JSON file")
     args = ap.parse_args(argv)
@@ -741,7 +740,7 @@ def cmd_benchmark(argv: list[str]) -> None:
                  else "on where a cliff is measured (default)")
     cpu_note = ("OFF (forced)" if args.cpu_split is not None and not args.cpu_split
                 else f"{args.cpu_split:.2f} (forced)" if args.cpu_split
-                else "calibrated fraction where it pays (default)")
+                else "OFF (default)")
     print(f"target: {target_repo}\n"
           f"hybrid lookup drafts: {lk_note}\n"
           f"small-M qmm kernel: {smm_note}\n"

--- a/src/mlx_dspark/generate.py
+++ b/src/mlx_dspark/generate.py
@@ -961,8 +961,8 @@ WIDE_GEMM_SHAPES = None    # allowlist of weight shapes verified bit-identical a
 CPU_SPLIT = None           # prefill CPU co-prefill: {"min_rows": N, "fracs": {width: frac}}
 # hands that fraction of each wide QuantizedLinear's rows to the CPU stream, concurrently
 # with the GPU (see wide_gemm.py). None disables — library default, since the split is
-# fp-tie class (like the last-row head) and its fraction is a measured constant; the
-# CLI/server set it from calibrate.apply_cpu_split (cached). M4 Pro / Qwen3.8-27B-4bit:
+# fp-tie class (like the last-row head); the CLI/server only set it when a fraction is
+# explicitly requested. M4 Pro / Qwen3.8-27B-4bit:
 # 1.41x prefill at a 0.3 fraction, greedy continuation token-identical.
 
 

--- a/src/mlx_dspark/generate.py
+++ b/src/mlx_dspark/generate.py
@@ -496,6 +496,7 @@ def greedy_generate(
     on_round=None,
     on_prefill=None,
     prefill_marks=None,
+    on_prefill_progress=None,
 ) -> GenResult:
     """Plain decoding of the target (no drafter, no hidden-state capture) — the fair
     'run the model normally' baseline. ``temperature`` 0 = greedy, > 0 = sampling (matches
@@ -518,7 +519,8 @@ def greedy_generate(
     suffix = ids[reuse_len:] if reuse_len else ids      # only prefill past the reused prefix
     logits = _prefill_plain(
         target_model, suffix, cache, base=reuse_len, marks=prefill_marks,
-        on_mark=(lambda p: on_prefill(cache, None, p)) if on_prefill else None)
+        on_mark=(lambda p: on_prefill(cache, None, p)) if on_prefill else None,
+        on_progress=on_prefill_progress)
     if on_prefill is not None:
         on_prefill(cache, None, len(ids))   # caches hold exactly `ids` right now
     mx.eval(logits)                          # settle prompt-eval so the prefill/decode timing split is
@@ -614,6 +616,7 @@ def dflash_generate(
     on_round=None,
     on_prefill=None,
     prefill_marks=None,
+    on_prefill_progress=None,
 ) -> GenResult:
     """Speculative decoding with a **z-lab DFlash** (block-diffusion) drafter.
 
@@ -738,7 +741,8 @@ def dflash_generate(
 
     logits, _ = _prefill_tapped(
         target_model, suffix, cache, tap, drafter=_Acc, ctx_offset=reuse_len,
-        marks=prefill_marks, on_mark=_mark if on_prefill is not None else None)
+        marks=prefill_marks, on_mark=_mark if on_prefill is not None else None,
+        on_progress=on_prefill_progress)
     if on_prefill is not None:
         _mark(len(ids))                # caches hold exactly `ids` (stable == n templates)
     mx.eval(logits)                    # settle prompt-eval so the prefill/decode timing split is honest
@@ -979,11 +983,12 @@ def _mark_stops(marks, base: int, n: int) -> list[int]:
 
 
 def _prefill_plain(target, ids: list[int], cache, chunk: int | None = None,
-                   base: int = 0, marks=None, on_mark=None):
+                   base: int = 0, marks=None, on_mark=None, on_progress=None):
     """Chunked no-tap prefill; returns the last chunk's logits [1, 1, V]. ``marks``
     (absolute positions, with ``base`` = tokens already in the caches) split chunks so
     ``on_mark(pos)`` runs while the caches hold exactly the first ``pos`` tokens — the
-    prefix cache snapshots its interior boundaries there."""
+    prefix cache snapshots its interior boundaries there. ``on_progress(pos)`` runs only
+    after that chunk's MLX work has materialized."""
     chunk = chunk or PREFILL_CHUNK      # read the module knob at call time
     stops = _mark_stops(marks, base, len(ids))
     logits = None
@@ -1000,6 +1005,10 @@ def _prefill_plain(target, ids: list[int], cache, chunk: int | None = None,
             if many and not last:
                 mx.eval(_cache_arrays(cache))
                 mx.clear_cache()
+            elif on_progress is not None:
+                mx.eval(logits, _cache_arrays(cache))
+            if on_progress is not None:
+                on_progress(base + end)
             if on_mark is not None and end in stops:
                 on_mark(base + end)
             i = end
@@ -1008,12 +1017,13 @@ def _prefill_plain(target, ids: list[int], cache, chunk: int | None = None,
 
 def _prefill_tapped(target, ids: list[int], cache, tap, drafter=None, ctx_caches=None,
                     ctx_offset: int = 0, chunk: int | None = None,
-                    marks=None, on_mark=None):
+                    marks=None, on_mark=None, on_progress=None):
     """Chunked prefill with the hidden-state tap. When ``drafter`` is given, each chunk's
     fused states feed the drafter context immediately (so a long prompt's fused activations
     never all materialize at once); returns (last logits, last chunk's fused). Without a
     drafter the fused chunks are concatenated (DFlash needs the whole prompt's fused).
-    ``marks``/``on_mark``: see :func:`_prefill_plain` (``ctx_offset`` is the base)."""
+    ``marks``/``on_mark`` and ``on_progress``: see :func:`_prefill_plain` (``ctx_offset``
+    is the base)."""
     chunk = chunk or PREFILL_CHUNK      # read the module knob at call time
     stops = _mark_stops(marks, ctx_offset, len(ids))
     logits = fused = None
@@ -1041,6 +1051,11 @@ def _prefill_tapped(target, ids: list[int], cache, tap, drafter=None, ctx_caches
                 mx.eval(_cache_arrays(cache),
                         [c.k for c in ctx_caches] if ctx_caches else fused)
                 mx.clear_cache()
+            elif on_progress is not None:
+                mx.eval(logits, _cache_arrays(cache), fused,
+                        [c.k for c in ctx_caches] if ctx_caches else [])
+            if on_progress is not None:
+                on_progress(ctx_offset + end)
             if on_mark is not None and end in stops:
                 on_mark(ctx_offset + end)
             i = end
@@ -1113,6 +1128,7 @@ def speculative_generate(
     on_round=None,
     on_prefill=None,
     prefill_marks=None,
+    on_prefill_progress=None,
     verbose: bool = False,
 ) -> GenResult:
     """Speculative decoding (batch=1).
@@ -1194,7 +1210,8 @@ def speculative_generate(
     logits, _ = _prefill_tapped(
         target_model, suffix, cache, tap,
         drafter=drafter, ctx_caches=ctx_caches, ctx_offset=reuse_len, marks=prefill_marks,
-        on_mark=(lambda p: on_prefill(cache, ctx_caches, p)) if on_prefill else None)
+        on_mark=(lambda p: on_prefill(cache, ctx_caches, p)) if on_prefill else None,
+        on_progress=on_prefill_progress)
     if on_prefill is not None:
         on_prefill(cache, ctx_caches, len(ids))   # caches hold exactly `ids` right now
     mx.eval(logits)                    # settle prompt-eval so the prefill/decode timing split is honest

--- a/src/mlx_dspark/lookup.py
+++ b/src/mlx_dspark/lookup.py
@@ -162,6 +162,7 @@ def lookup_generate(
     on_round=None,
     on_prefill=None,
     prefill_marks=None,
+    on_prefill_progress=None,
 ) -> GenResult:
     """Prompt-lookup speculative decoding (batch=1) — no drafter model.
 
@@ -193,7 +194,8 @@ def lookup_generate(
     suffix = ids[reuse_len:] if reuse_len else ids
     logits = _prefill_plain(
         target_model, suffix, cache, base=reuse_len, marks=prefill_marks,
-        on_mark=(lambda p: on_prefill(cache, None, p)) if on_prefill else None)
+        on_mark=(lambda p: on_prefill(cache, None, p)) if on_prefill else None,
+        on_progress=on_prefill_progress)
     if on_prefill is not None:
         on_prefill(cache, None, len(ids))   # caches hold exactly `ids` right now
     pending = _pick(logits[0, -1], temperature, top_p, top_k)

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -608,7 +608,7 @@ class Engine:
         kv_bits: int | None = None,              # quantize the target KV cache (4/8)
         context_window: int | None = None,       # override the target's own limit
         wide_gemm_min: int | None = None,        # prefill wide-GEMM: None=calibrate, 0=off, N=forced
-        cpu_split: float | None = None,          # prefill CPU co-prefill: None=calibrate, 0=off, f=forced
+        cpu_split: float | str | None = None,    # prefill CPU co-prefill: None/0=off, auto/f
         small_m: bool | None = None,             # small-M MMA verify kernel: None=probe-gated
         #                                          default, False=force off (serve-side A/B)
         sdpa_split: bool | None = None,          # wide-verify SDPA split: None=probe-gated, False=off
@@ -683,7 +683,7 @@ class Engine:
             from .calibrate import apply_wide_gemm
 
             apply_wide_gemm(tgt, draft, target_repo=target_repo, min_rows=wide_gemm_min)
-            # prefill CPU co-prefill (see wide_gemm.py): a measured fraction of each wide
+            # optional CPU co-prefill (see wide_gemm.py): an explicit fraction of each wide
             # matmul's rows on the CPU stream, concurrently with the GPU. Same rails.
             from .calibrate import apply_cpu_split
 
@@ -1880,7 +1880,7 @@ class EngineHolder:
              context_window: int | None = None,
              small_m: bool | None = None,
              sdpa_split: bool | None = None,
-             cpu_split: float | None = None,
+             cpu_split: float | str | None = None,
              kv_bits: int | None = None,
              warmup: bool | None = None,
              memory_guard: bool | None = None,
@@ -1931,6 +1931,10 @@ class EngineHolder:
                     self._load_kwargs["enable_thinking"] = None if enable_thinking else False
                 if reasoning_effort is not None:
                     self._load_kwargs["reasoning_effort"] = reasoning_effort
+                # Session-sticky like context_window: one app toggle covers later model
+                # swaps, but a fresh server still starts safely off.
+                if cpu_split is not None:
+                    self._load_kwargs["cpu_split"] = cpu_split
                 kwargs = dict(self._load_kwargs)
                 kwargs["model"] = model
                 if mode is not None:
@@ -1945,8 +1949,6 @@ class EngineHolder:
                     kwargs["small_m"] = small_m
                 if sdpa_split is not None:
                     kwargs["sdpa_split"] = sdpa_split
-                if cpu_split is not None:
-                    kwargs["cpu_split"] = cpu_split       # 0 -> off, float -> forced fraction
                 if kv_bits is not None:
                     kwargs["kv_bits"] = kv_bits or None    # 0 -> full precision
                 if warmup is not None:
@@ -2205,9 +2207,9 @@ def make_handler(engine: Engine, api_key: str | None):
                     # mlx's multi-row cliff and it wasn't forced off) — pairs with serve
                     # --no-sdpa-split / the /admin/load "sdpa_split" override
                     "sdpa_split": bool(getattr(engine, "sdpa_split", False)),
-                    # prefill CPU co-prefill: the calibrated {min_rows, fracs} in force, or
+                    # prefill CPU co-prefill: the configured {min_rows, fracs} in force, or
                     # null when off — pairs with serve --cpu-split / the /admin/load
-                    # "cpu_split" override (0 = off) for a prefill A/B without a restart
+                    # "cpu_split" override ("auto" or fraction; 0 = off) without a restart
                     "cpu_split": getattr(engine, "cpu_split", None),
                     # whether this load ran a warmup pass (throwaway generation to compile
                     # kernels + ramp the clock so the first real request is warm). On by
@@ -2371,13 +2373,15 @@ def make_handler(engine: Engine, api_key: str | None):
                                              "stock verify kernel; omit it to use the "
                                              "server's setting)")
             cpu_split = req.get("cpu_split")
-            if cpu_split is not None and (isinstance(cpu_split, bool)
-                                          or not isinstance(cpu_split, (int, float))
-                                          or not 0 <= cpu_split < 1):
-                return self._send_error(400, "'cpu_split' must be a number in [0, 1): 0 forces "
-                                             "prefill CPU co-prefill off, a fraction pins the "
-                                             "CPU row share; omit it to use the server's "
-                                             "calibrated setting")
+            valid_cpu_split = (cpu_split == "auto"
+                               or (not isinstance(cpu_split, bool)
+                                   and isinstance(cpu_split, (int, float))
+                                   and 0 <= cpu_split < 1))
+            if cpu_split is not None and not valid_cpu_split:
+                return self._send_error(400, "'cpu_split' must be 'auto' or a number in "
+                                             "[0, 1): 0 forces prefill CPU co-prefill off, "
+                                             "a fraction pins the CPU row share; omit it to "
+                                             "keep the server's setting (off by default)")
             sdpa_split = req.get("sdpa_split")
             if sdpa_split is not None and not isinstance(sdpa_split, bool):
                 return self._send_error(400, "'sdpa_split' must be a boolean (false forces the "

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -2280,8 +2280,10 @@ def make_handler(engine: Engine, api_key: str | None):
                 # Chip, measured bandwidth, OS memory view, the loaded model's footprint and
                 # its single-stream roofline. Answers model-less too (chip/bandwidth/memory
                 # only) so a picker can scale estimates before anything is loaded.
+                if isinstance(engine, EngineHolder) and not engine.ready:
+                    return self._send_json(200, _machine_basics())
                 report = getattr(engine, "machine_report", None)
-                if (isinstance(engine, EngineHolder) and not engine.ready) or report is None:
+                if report is None:
                     return self._send_json(200, _machine_basics())
                 return self._send_json(200, report())
             if not self._require_ready():

--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -928,6 +928,22 @@ class Engine:
                         self.prefix.checkpoint(c, x, pos, _ids)
                     elif pos < _stable:
                         self.prefix.rung(c, pos)
+        prefill_position = [reuse_len]
+        on_prefill_progress = None
+        if reuse_len < len(prompt_ids):
+            def publish_prefill(pos, active):
+                pos = int(pos)
+                prefill_position[0] = pos
+                self.rounds.publish("prefill", {
+                    "req": recorder.request_id,
+                    "mode": self.mode,
+                    "processed": pos,
+                    "total": len(prompt_ids),
+                    "active": bool(active),
+                })
+
+            def on_prefill_progress(pos):
+                publish_prefill(pos, pos < len(prompt_ids))
         # Depth-aware cap for DERIVED defaults: a long prompt shrinks the verify width,
         # because verify cost carries a measured width-x-depth KV-read term the flat
         # chat-depth curves can't see (cap 7 at 32k measured 1.05x vs cap 3's 1.48x;
@@ -943,6 +959,8 @@ class Engine:
                 len(prompt_ids), default, STATIC_PRIOR_P)
         self._last_cap = eff_cap
         try:
+            if on_prefill_progress is not None:
+                publish_prefill(reuse_len, True)
             if self.mode == "dspark":
                 res = speculative_generate(
                     self.target, self.tokenizer, self.drafter, prompt_ids=prompt_ids,
@@ -955,6 +973,7 @@ class Engine:
                     presence_penalty=presence_penalty, frequency_penalty=frequency_penalty,
                     logprobs=logprobs, seed=seed, stop=stop, on_text=on_text,
                     on_round=on_round, on_prefill=on_prefill, prefill_marks=prefill_marks,
+                    on_prefill_progress=on_prefill_progress,
                 )
             elif self.mode == "dflash":
                 res = dflash_generate(
@@ -965,6 +984,7 @@ class Engine:
                     temperature=temperature, top_p=top_p, top_k=top_k,
                     seed=seed, stop=stop, on_text=on_text, on_round=on_round,
                     on_prefill=on_prefill, prefill_marks=prefill_marks,
+                    on_prefill_progress=on_prefill_progress,
                 )
             elif self.mode == "lookup":
                 res = lookup_generate(
@@ -975,6 +995,7 @@ class Engine:
                     temperature=temperature, top_p=top_p, top_k=top_k,
                     seed=seed, stop=stop, on_text=on_text, on_round=on_round,
                     on_prefill=on_prefill, prefill_marks=prefill_marks,
+                    on_prefill_progress=on_prefill_progress,
                 )
             else:
                 res = greedy_generate(
@@ -985,8 +1006,11 @@ class Engine:
                     frequency_penalty=frequency_penalty, logprobs=logprobs, seed=seed,
                     stop=stop, on_text=on_text, on_round=on_round,
                     on_prefill=on_prefill, prefill_marks=prefill_marks,
+                    on_prefill_progress=on_prefill_progress,
                 )
         except BaseException:                     # never leave a desynced cache behind
+            if on_prefill_progress is not None and prefill_position[0] < len(prompt_ids):
+                publish_prefill(prefill_position[0], False)
             if self.prefix is not None:
                 self.prefix.reset()
             raise
@@ -2517,7 +2541,7 @@ def make_handler(engine: Engine, api_key: str | None):
                 return default
 
         def _events_stream(self):
-            """SSE stream of per-round telemetry.
+            """SSE stream of live generation telemetry.
 
             Deliberately independent of any one request: a client opens this once and watches
             every round the engine runs, whoever asked for it. That is what lets a UI show a
@@ -2561,7 +2585,11 @@ def make_handler(engine: Engine, api_key: str | None):
                             self._sse(log.stats(), "stats")
                             idle = 0.0
                         continue
-                    self._sse(event, "round")
+                    if isinstance(event, tuple):
+                        event_name, event = event
+                    else:
+                        event_name = "round"
+                    self._sse(event, event_name)
             except (BrokenPipeError, ConnectionResetError):
                 pass                     # client went away; nothing to report
             finally:

--- a/src/mlx_dspark/telemetry.py
+++ b/src/mlx_dspark/telemetry.py
@@ -98,6 +98,14 @@ class RoundLog:
             with contextlib.suppress(queue.Full):   # a slow client must never stall generation
                 q.put_nowait(event)
 
+    def publish(self, event_name: str, event: dict) -> None:
+        """Fan out a named live event without adding it to round history or aggregates."""
+        with self._lock:
+            subscribers = tuple(self._subscribers)
+        for q in subscribers:
+            with contextlib.suppress(queue.Full):
+                q.put_nowait((event_name, event))
+
     # ------------------------------------------------------------------ reading
 
     def snapshot(self, limit: int | None = None) -> list[dict]:

--- a/src/mlx_dspark/wide_gemm.py
+++ b/src/mlx_dspark/wide_gemm.py
@@ -59,8 +59,8 @@ peak, 64-token greedy continuation token-identical.
 
 Not bit-identical: the CPU rows are a different accumulation order (fp-tie class —
 max|Δlogit| 2.0 on the 27B's final row vs 1.55 for chunked prefill and 2.0 for the
-unverified wide path, i.e. the same band). Hence the CLI/server turn it on (like the
-last-row head slice and the small-M kernel) and the library API leaves it off. The
+unverified wide path, i.e. the same band). Hence it is an explicit CLI/server opt-in and
+the library API leaves it off. The
 fraction and the row floor are (chip x mlx x model) constants: ``measure_cpu_split``
 finds the best fraction per width — it falls off a cliff past the balance point (M4
 Pro: 0.3 at 2048 rows, 1.41x; 0.45 is 1.08x) — and the caller caches it.

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -6,10 +6,28 @@ from __future__ import annotations
 from mlx_dspark.calibrate import (
     CapController,
     _cache_key,
+    apply_cpu_split,
     _interp,
     load_cached,
     save_cached,
 )
+
+
+def test_cpu_split_is_opt_in_or_auto(monkeypatch):
+    import importlib
+
+    calibrate = importlib.import_module("mlx_dspark.calibrate")
+    generate = importlib.import_module("mlx_dspark.generate")
+    monkeypatch.setattr(generate, "CPU_SPLIT", {"stale": True})
+
+    assert apply_cpu_split(None, target_repo="unused", verbose=False) is None
+    assert generate.CPU_SPLIT is None
+    assert apply_cpu_split(None, target_repo="unused", frac=0.25, verbose=False)["fracs"] == {
+        256: 0.25,
+    }
+    measured = {"min_rows": 512, "fracs": {512: 0.2}}
+    monkeypatch.setattr(calibrate, "cpu_split_config", lambda *a, **kw: measured)
+    assert apply_cpu_split(None, target_repo="unused", frac="auto", verbose=False) is measured
 
 
 def test_interp_exact_between_and_extrapolate():

--- a/tests/test_generate_helpers.py
+++ b/tests/test_generate_helpers.py
@@ -227,7 +227,7 @@ def test_mark_stops_are_suffix_relative_and_interior():
     assert _mark_stops([15], base=5, n=10) == []               # the end is not a mark stop
 
 
-def test_prefill_plain_splits_chunks_at_marks_and_reports_positions():
+def test_prefill_plain_splits_chunks_at_marks_and_reports_positions(monkeypatch):
     import mlx.core as mx
 
     from mlx_dspark.generate import _prefill_plain
@@ -250,14 +250,28 @@ def test_prefill_plain_splits_chunks_at_marks_and_reports_positions():
     tgt = Tgt()
     cache = [Layer()]
     seen = []
+    progress = []
+    timeline = []
+    real_eval = mx.eval
+
+    def tracked_eval(*args):
+        result = real_eval(*args)
+        timeline.append("eval")
+        return result
+
+    monkeypatch.setattr(mx, "eval", tracked_eval)
     ids = list(range(100, 112))                     # 12 suffix tokens after base 5
     _prefill_plain(tgt, ids, cache, chunk=8, base=5, marks=[8, 14],
-                   on_mark=lambda p: seen.append((p, cache[0].offset)))
+                   on_mark=lambda p: seen.append((p, cache[0].offset)),
+                   on_progress=lambda p: (progress.append(p), timeline.append(p)))
     # chunks split at the marks (8-5=3, 14-5=9); chunk is a max piece size, not a grid
     assert tgt.chunks == [3, 6, 3]
     # on_mark fires with the caches holding exactly the first `pos` tokens (offset is
     # suffix-relative here: 3 and 9 of the 12)
     assert seen == [(8, 3), (14, 9)]
+    assert progress == [8, 14, 17]                  # every evaluated chunk, including final
+    assert all(timeline[i - 1] == "eval" for i, item in enumerate(timeline)
+               if isinstance(item, int))
 
 
 # ------------------------------------------------------- enable_thinking force-close (LFM2.5)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -883,6 +883,13 @@ def test_health_reports_small_m(server):
     assert _get(base, "/health")["small_m"] is True
 
 
+def test_health_reports_cpu_split(server):
+    eng, base = server
+    assert _get(base, "/health")["cpu_split"] is None
+    eng.cpu_split = {"min_rows": 512, "fracs": {512: 0.2}}
+    assert _get(base, "/health")["cpu_split"]["min_rows"] == 512
+
+
 # --- on-load warmup: kernels are primed before "ready" so the first request is fast --------
 
 
@@ -924,6 +931,22 @@ def test_admin_load_rejects_bad_warmup(holder_server):
             _post(base, "/admin/load", {"model": "repo", "warmup": bad})
         assert e.value.code == 400, bad
         assert "warmup" in json.loads(e.value.read())["error"]["message"]
+
+
+def test_admin_load_validates_and_passes_cpu_split(holder_server):
+    holder, base = holder_server
+    seen = []
+    holder.swap = lambda **kw: seen.append(kw) or holder.status()
+
+    _post(base, "/admin/load", {"model": "repo", "cpu_split": "auto"})
+    _post(base, "/admin/load", {"model": "repo", "cpu_split": 0.25})
+    assert [call["cpu_split"] for call in seen] == ["auto", 0.25]
+
+    for bad in ("fast", True, -0.1, 1):
+        with pytest.raises(urllib.error.HTTPError) as e:
+            _post(base, "/admin/load", {"model": "repo", "cpu_split": bad})
+        assert e.value.code == 400, bad
+        assert "cpu_split" in json.loads(e.value.read())["error"]["message"]
 
 
 class _SlowStreamEngine(_FakeEngine):
@@ -1347,6 +1370,24 @@ def test_swap_makes_thinking_default_sticky(monkeypatch):
     assert seen[0]["enable_thinking"] is False and seen[0]["reasoning_effort"] == "low"
     assert seen[1]["enable_thinking"] is False and seen[1]["reasoning_effort"] == "low"
     assert seen[2]["enable_thinking"] is None
+
+
+def test_swap_keeps_cpu_split_only_for_the_server_session(monkeypatch):
+    seen = []
+
+    class _E:
+        model_id = "m"
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(S.Engine, "load", staticmethod(lambda **kw: seen.append(kw) or _E()))
+    monkeypatch.setattr(S, "maybe_batch_engine", lambda e, n: e)
+    holder = S.EngineHolder(None, {"mode": "auto", "cpu_split": None})
+    holder.swap(model="a", cpu_split="auto")
+    holder.swap(model="b")
+    holder.swap(model="c", cpu_split=0)
+    assert [call["cpu_split"] for call in seen] == ["auto", "auto", 0]
 
 
 # ------------------------------------------------------------------ issue #27: GET auth

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -276,8 +276,8 @@ def test_metrics_reports_allocator_memory(server):
         assert memory["active_bytes"] >= 0 and memory["peak_bytes"] >= 0
 
 
-def test_events_stream_ends_cleanly_across_a_model_swap():
-    """A hot swap replaces the engine (and its round log) under a live /events stream.
+def test_events_stream_names_prefill_and_ends_cleanly_across_a_model_swap():
+    """Named live events share the stream, which still ends cleanly on a hot swap.
 
     The stream must END — so the client reconnects to the new engine's log — never
     traceback through the holder's no-engine guard (that stack trace lands in the app's
@@ -300,6 +300,12 @@ def test_events_stream_ends_cleanly_across_a_model_swap():
     base = f"http://127.0.0.1:{port}"
     try:
         stream = urllib.request.urlopen(base + "/events", timeout=5)
+        payload = {"req": "abc", "mode": "dflash", "processed": 2048,
+                   "total": 22000, "active": True}
+        holder._engine.rounds.publish("prefill", payload)
+        while stream.readline() != b"event: prefill\n":
+            pass
+        assert json.loads(stream.readline().removeprefix(b"data: ")) == payload
         # Swap the engine out from under the stream (a real swap loads weights; identity
         # of `rounds` changing is all the stream watches).
         holder._engine = Eng()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1214,6 +1214,22 @@ def test_machine_answers_for_any_engine(server):
     assert m["model"] is None
 
 
+def test_machine_answers_during_model_swap():
+    """/machine stays usable while an EngineHolder has temporarily no engine."""
+    from mlx_dspark.server import EngineHolder
+
+    holder = EngineHolder(None, load_kwargs={})
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), S.make_handler(holder, api_key=None))
+    port = httpd.server_address[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        machine = _get(f"http://127.0.0.1:{port}", "/machine")
+        assert machine["model"] is None
+        assert "chip" in machine and "memory" in machine
+    finally:
+        httpd.shutdown()
+
+
 def test_admin_models_reports_bandwidth_scale(server):
     _, base = server
     bw = _get(base, "/admin/models")["bandwidth"]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -147,6 +147,15 @@ class TestFanOut:
         log.record(_round(committed=5))
         assert all(q.get_nowait()["committed"] == 5 for q in qs)
 
+    def test_named_event_is_live_only(self):
+        log = RoundLog()
+        q = log.subscribe()
+        event = {"req": "abc", "processed": 2048, "total": 22000, "active": True}
+        log.publish("prefill", event)
+        assert q.get_nowait() == ("prefill", event)
+        assert log.snapshot() == []
+        assert log.stats()["rounds"] == 0
+
     def test_slow_subscriber_never_blocks_the_writer(self):
         """A stalled HTTP client must not be able to stall token generation."""
         from mlx_dspark.telemetry import SUBSCRIBER_BACKLOG

--- a/tests/test_wide_gemm.py
+++ b/tests/test_wide_gemm.py
@@ -217,8 +217,8 @@ def test_cpu_rows_is_tile_rounded_and_never_everything():
 
 def test_split_matches_plain_path_within_bf16_and_restores():
     """The CPU rows are a different accumulation order (fp-tie class), so agreement is
-    'within bf16 rounding', not bit-identity — that is exactly why the library leaves
-    this off and the CLI turns it on, like the last-row head."""
+    'within bf16 rounding', not bit-identity — that is exactly why the library and CLI
+    leave it off unless explicitly requested."""
     mx.random.seed(3)
     lin = _qlinear(bits=4)
     x = mx.random.normal((ROWS, K)).astype(mx.bfloat16)


### PR DESCRIPTION
Closes #29

## Summary

- emit non-recorded `prefill` telemetry after each evaluated 2,048-token chunk
- surface progress for external clients such as Hermes in the Mac status bar
- clear progress on completion, errors, stream loss, and model changes without affecting decode statistics

The change is observational only: it does not alter token selection, target verification, model loading, or prefix-cache behavior, so lossless generation is preserved. The target model for this issue is the Qwen3.8 27B model paired with `incoai/Qwen3.8-27B-DFlash2`.

## Tests

- `uv run --extra dev pytest tests/ -q` — 724 passed
- `uv run --extra dev pytest tests/test_generate_helpers.py -q` — 19 passed after the final callback-order check
- `ruff check src tests` — passed for the changed Python files
- `swift test` — 25 passed

## Live verification

A cold external Hermes request with 22,090 input tokens displayed chunk progress throughout prefill and cleared when decode began. An immediate repeat reused 22,089 / 22,126 cached tokens.