### PR TITLE
Fix /machine after model unload

### DIFF
--- a/src/mlx_dspark/server.py
+++ b/src/mlx_dspark/server.py
@@ -2278,8 +2278,10 @@ def make_handler(engine: Engine, api_key: str | None):
                 # Chip, measured bandwidth, OS memory view, the loaded model's footprint and
                 # its single-stream roofline. Answers model-less too (chip/bandwidth/memory
                 # only) so a picker can scale estimates before anything is loaded.
+                if isinstance(engine, EngineHolder) and not engine.ready:
+                    return self._send_json(200, _machine_basics())
                 report = getattr(engine, "machine_report", None)
-                if (isinstance(engine, EngineHolder) and not engine.ready) or report is None:
+                if report is None:
                     return self._send_json(200, _machine_basics())
                 return self._send_json(200, report())
             if not self._require_ready():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -742,6 +742,16 @@ def test_admin_unload_frees_the_engine(holder_server):
     assert _post(base, "/admin/unload", {})["ready"] is False
 
 
+def test_machine_answers_after_unload(holder_server):
+    """The Mac app polls /machine after unloading; that must remain model-free."""
+    _holder, base = holder_server
+    _post(base, "/admin/unload", {})
+
+    payload = _get(base, "/machine")
+
+    assert "memory" in payload
+
+
 def test_inventory_routes_answer_without_a_model(holder_server):
     """/doctor and /admin/models are model-free by design — a picker must work from the
     no-model state. /admin/models reports loaded=None there."""


### PR DESCRIPTION
Fixes the model-less `/machine` path used by the native Mac app after `POST /admin/unload`. The handler previously called `getattr` on `EngineHolder` before checking `ready`, which raised while the app polled its roofline view. The new regression test performs a real unload through the HTTP handler and verifies `/machine` remains available.